### PR TITLE
Add Konsta and Framework7 sample setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.5"
+    "next": "15.4.5",
+    "framework7": "^8.0.0",
+    "framework7-react": "^8.0.0",
+    "konsta": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import "framework7/framework7-bundle.css";
+@import "konsta/css";
 @import "tailwindcss";
 
 :root {

--- a/src/app/konsta/page.tsx
+++ b/src/app/konsta/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { App as Framework7App, View } from "framework7-react";
+import { Page, Navbar, Block, Button } from "konsta/react";
+
+export default function KonstaPage() {
+  return (
+    <Framework7App theme="ios">
+      <View main>
+        <Page>
+          <Navbar title="Konsta + Framework7" />
+          <Block strong className="space-y-4">
+            <p>Hello from Konsta!</p>
+            <Button>Click Me</Button>
+          </Block>
+        </Page>
+      </View>
+    </Framework7App>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from "tailwindcss";
+import framework7 from "framework7/plugin";
+import konsta from "konsta/plugin";
+
+const config: Config = {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [framework7, konsta],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Konsta, Framework7 and Framework7 React dependencies
- configure Tailwind to load Konsta and Framework7 plugins
- include Framework7/Konsta CSS and sample Konsta page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`: https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap
Please check your network connection., Module not found: Can't resolve 'framework7-react', Module not found: Can't resolve 'konsta/react`)*
- `npm install framework7 framework7-react konsta` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_688f6a7729248323a415f90ac303cff5