### PR TITLE
fix framework7 tailwind integration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "framework7/framework7-bundle.css";
+@import "framework7/css/bundle";
 @import "konsta/css";
 @import "tailwindcss";
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,4 @@
 import type { Config } from "tailwindcss";
-import framework7 from "framework7/plugin";
 import konsta from "konsta/plugin";
 
 const config: Config = {
@@ -7,7 +6,7 @@ const config: Config = {
   theme: {
     extend: {},
   },
-  plugins: [framework7, konsta],
+  plugins: [konsta],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- remove non-existent `framework7/plugin` from Tailwind config
- import Framework7 CSS via package export `framework7/css/bundle`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_688f69905a108323a42992333234b166