### PR TITLE
fix konsta tailwind configuration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,4 @@
-@import "framework7/framework7-bundle.css";
-@import "konsta/css";
+@import "framework7/css/bundle";
 @import "tailwindcss";
 
 :root {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,9 @@
 import type { Config } from "tailwindcss";
-import framework7 from "framework7/plugin";
-import konsta from "konsta/plugin";
+import konsta from "konsta/config";
 
-const config: Config = {
+export default konsta({
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
   },
-  plugins: [framework7, konsta],
-};
-
-export default config;
+}) satisfies Config;


### PR DESCRIPTION
## Summary
- configure Tailwind via `konsta/config` instead of nonexistent plugin
- drop invalid `konsta/css` import from global stylesheet

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688f69905a108323a42992333234b166