### PR TITLE
feat: add telegram mini app demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Telegram Mini App Demo
+
+This project includes a simple Telegram Mini App example built with Framework7, Konsta UI and TailwindCSS. Visit `/telegram` while running the development server to see a small form that reads Telegram WebApp user data and collects birth details locally.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -24,6 +25,13 @@ export default function Home() {
             Save and see your changes instantly.
           </li>
         </ol>
+
+        <Link
+          href="/telegram"
+          className="text-blue-500 underline"
+        >
+          Open Telegram Mini App Demo
+        </Link>
 
         <div className="flex gap-4 items-center flex-col sm:flex-row">
           <a

--- a/src/app/telegram/page.tsx
+++ b/src/app/telegram/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { App as Framework7App, View } from "framework7-react";
+import { Page, Navbar, Block, List, ListInput, Button } from "konsta/react";
+
+interface TelegramWebApp {
+  expand: () => void;
+  initDataUnsafe?: {
+    user?: {
+      first_name?: string;
+    };
+  };
+}
+
+declare global {
+  interface Window {
+    Telegram?: { WebApp?: TelegramWebApp };
+  }
+}
+
+export default function TelegramPage() {
+  const [telegramUser, setTelegramUser] = useState<string | undefined>();
+  const [birthDate, setBirthDate] = useState("");
+  const [birthTime, setBirthTime] = useState("");
+  const [birthPlace, setBirthPlace] = useState("");
+
+  useEffect(() => {
+    const tg = window.Telegram?.WebApp;
+    if (tg) {
+      tg.expand();
+      setTelegramUser(tg.initDataUnsafe?.user?.first_name);
+    }
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const message = `Birth info:\nDate: ${birthDate}\nTime: ${birthTime}\nPlace: ${birthPlace}`;
+    alert(message);
+  };
+
+  return (
+    <Framework7App theme="ios">
+      <View main>
+        <Page>
+          <Navbar title="AstroT" />
+          <Block strong>
+            {telegramUser && <p className="mb-4">Hello, {telegramUser}!</p>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <List strong inset>
+                <ListInput
+                  label="Date of Birth"
+                  type="date"
+                  value={birthDate}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setBirthDate(e.target.value)
+                  }
+                />
+                <ListInput
+                  label="Time of Birth"
+                  type="time"
+                  value={birthTime}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setBirthTime(e.target.value)
+                  }
+                />
+                <ListInput
+                  label="Place of Birth"
+                  type="text"
+                  value={birthPlace}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setBirthPlace(e.target.value)
+                  }
+                  placeholder="City"
+                />
+              </List>
+              <Button type="submit">Save</Button>
+            </form>
+          </Block>
+        </Page>
+      </View>
+    </Framework7App>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add simple Framework7/Konsta page that integrates Telegram WebApp API and collects birth data
- link demo from home page
- document Telegram demo in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f730113788323ac33c362889e5f86