### PR TITLE
Handle Konsta button without unsupported type prop

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,4 @@
 @import "framework7/css/bundle";
-@import "konsta/css";
 @import "tailwindcss";
 
 :root {

--- a/src/app/telegram/page.tsx
+++ b/src/app/telegram/page.tsx
@@ -37,7 +37,9 @@ export default function TelegramPage() {
     }
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (
+    e: React.FormEvent | React.MouseEvent
+  ) => {
     e.preventDefault();
     if (!telegramId) return;
     try {
@@ -89,7 +91,7 @@ export default function TelegramPage() {
                   placeholder="City"
                 />
               </List>
-              <Button type="submit">Save</Button>
+              <Button onClick={handleSubmit}>Save</Button>
             </form>
           </Block>
         </Page>


### PR DESCRIPTION
## Summary
- Allow Konsta button to submit form via click handler to avoid unsupported `type` prop
- Drop unused `konsta/css` import to avoid package export errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_688f7db3f6888323825d5dd843b50ccd