### PR TITLE
fix: update konsta plugin import

### DIFF
--- a/konsta-config.d.ts
+++ b/konsta-config.d.ts
@@ -1,0 +1,5 @@
+declare module "konsta/config" {
+  import type { Config } from "tailwindcss";
+  const konstaConfig: (config?: Config) => Config;
+  export default konstaConfig;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,12 +1,12 @@
 import type { Config } from "tailwindcss";
-import konsta from "konsta/plugin";
+import konstaConfig from "konsta/config";
 
-const config: Config = {
+const config = konstaConfig({
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
   },
-  plugins: [konsta],
-};
+  plugins: [],
+}) satisfies Config;
 
 export default config;


### PR DESCRIPTION
## Summary
- replace nonexistent `konsta/plugin` import with `konsta/config` configuration function
- add local type declaration for `konsta/config`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch Geist fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688f80d5ae3883239d94601732a48e5b