### PR TITLE
feat: add telegram webhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project includes a simple Telegram Mini App example built with Framework7, Konsta UI and TailwindCSS. Visit `/telegram` while running the development server to see a small form that reads Telegram WebApp user data and collects birth details locally.
 
+To integrate the mini app with an actual Telegram Bot, configure your bot's webhook to point to `/api/telegram`. The route accepts `GET` for health checks and `POST` for updates, preventing Telegram from receiving a 404 when calling your server.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/src/app/api/telegram/route.ts
+++ b/src/app/api/telegram/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET() {
+  // Simple health check to avoid 404 when Telegram pings the webhook
+  return NextResponse.json({ ok: true });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const update = await req.json();
+    console.log("Telegram update", update);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Failed to process Telegram update", err);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal `/api/telegram` endpoint to avoid 404 when Telegram pings the bot
- document webhook usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f9e0a4c8c83238d434c2a712ca56d