### PR TITLE
fix: ensure Next.js app router defaults

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,7 @@
 @import "framework7/css/bundle";
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -28,7 +17,7 @@ export default function RootLayout({
       <head>
         <Script src="https://telegram.org/js/telegram-web-app.js" strategy="beforeInteractive" />
       </head>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- remove failing Google font imports and simplify root layout
- use standard Tailwind directives in global styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fa98c7e308323ac3bf5dd0c443da9