### PR TITLE
feat: add natal chart and cosmic loader

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,29 +1,6 @@
+import CosmicLoader from "../components/CosmicLoader";
+
 export default function Loading() {
-  return (
-    <div className="flex h-screen items-center justify-center bg-gradient-to-b from-black via-indigo-900 to-black text-white">
-      <div className="text-center">
-        <svg
-          className="mx-auto mb-4 h-12 w-12 animate-spin text-indigo-400"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          ></circle>
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-          ></path>
-        </svg>
-        <p className="text-xl">Загрузка Вселенной...</p>
-      </div>
-    </div>
-  );
+  return <CosmicLoader message="Загрузка Вселенной..." />;
 }
+

--- a/src/app/natal/loading.tsx
+++ b/src/app/natal/loading.tsx
@@ -1,0 +1,6 @@
+import CosmicLoader from "../../components/CosmicLoader";
+
+export default function Loading() {
+  return <CosmicLoader message="Загрузка натальной карты..." />;
+}
+

--- a/src/app/natal/page.tsx
+++ b/src/app/natal/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+function NatalChart() {
+  const lines = Array.from({ length: 12 });
+  return (
+    <svg viewBox="0 0 200 200" className="h-64 w-64 text-indigo-300">
+      <circle cx="100" cy="100" r="95" stroke="currentColor" strokeWidth="2" fill="none" />
+      {lines.map((_, i) => {
+        const angle = (i / 12) * Math.PI * 2;
+        const x = 100 + 95 * Math.cos(angle);
+        const y = 100 + 95 * Math.sin(angle);
+        return <line key={i} x1="100" y1="100" x2={x} y2={y} stroke="currentColor" strokeWidth="1" />;
+      })}
+    </svg>
+  );
+}
+
+export default function NatalPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-indigo-950 via-black to-indigo-950 text-white">
+      <h1 className="mb-8 text-4xl font-bold">Натальная карта</h1>
+      <NatalChart />
+      <Link href="/" className="mt-8 underline">
+        На главную
+      </Link>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,13 @@
 // src/app/page.tsx
+import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <div className="flex h-screen items-center justify-center bg-gradient-to-b from-black via-purple-900 to-black text-white text-3xl">
-      Astrot работает! 🚀
+    <div className="flex h-screen flex-col items-center justify-center bg-gradient-to-b from-black via-purple-900 to-black text-white text-3xl">
+      <p className="mb-6">Astrot работает! 🚀</p>
+      <Link href="/natal" className="text-xl underline">
+        Перейти к натальной карте
+      </Link>
     </div>
   );
 }

--- a/src/components/CosmicLoader.tsx
+++ b/src/components/CosmicLoader.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useMemo } from "react";
+
+type Props = {
+  message: string;
+};
+
+export default function CosmicLoader({ message }: Props) {
+  const stars = useMemo(
+    () =>
+      Array.from({ length: 60 }).map(() => ({
+        left: Math.random() * 100,
+        top: Math.random() * 100,
+        delay: Math.random() * 5,
+        duration: 2 + Math.random() * 3,
+      })),
+    []
+  );
+
+  return (
+    <div className="relative flex h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-black via-indigo-950 to-black text-white">
+      <div className="absolute inset-0 -z-10">
+        {stars.map((star, i) => (
+          <span
+            key={i}
+            className="absolute h-1 w-1 rounded-full bg-white opacity-70 animate-pulse"
+            style={{
+              left: `${star.left}%`,
+              top: `${star.top}%`,
+              animationDelay: `${star.delay}s`,
+              animationDuration: `${star.duration}s`,
+            }}
+          />
+        ))}
+      </div>
+      <div className="text-center">
+        <svg
+          className="mx-auto mb-4 h-12 w-12 animate-spin text-indigo-400"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          ></circle>
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          ></path>
+        </svg>
+        <p className="text-xl">{message}</p>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable CosmicLoader with animated starfield
- create natal chart page displaying simple zodiac wheel
- link to natal chart page from home

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688fbbb5b2a48323a34c7e5d200042b6