### PR TITLE
Show Telegram user info on launch

### DIFF
--- a/app/telegram/page.tsx
+++ b/app/telegram/page.tsx
@@ -65,7 +65,12 @@ export default function TelegramPage() {
         <Page>
           <Navbar title="AstroT" />
           <Block strong>
-            {telegramUser && <p className="mb-4">Hello, {telegramUser}!</p>}
+            {(telegramUser || telegramId) && (
+              <p className="mb-4">
+                {telegramUser && <>Hello, {telegramUser}! </>}
+                {telegramId && <>Your Telegram ID is {telegramId}.</>}
+              </p>
+            )}
             <form onSubmit={handleSubmit} className="space-y-4">
               <List strong inset>
                 <ListInput


### PR DESCRIPTION
## Summary
- display Telegram user's name and ID when opened as a Telegram Mini App

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b326fb0483239c263aceec069956