### PR TITLE
Handle missing Telegram username

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,11 @@ export default function HomePage() {
   useEffect(() => {
     const tg = window.Telegram?.WebApp;
     if (tg?.initDataUnsafe?.user) {
-      setTelegramUser(tg.initDataUnsafe.user.username || tg.initDataUnsafe.user.first_name);
+      const name =
+        tg.initDataUnsafe.user.username ||
+        tg.initDataUnsafe.user.first_name ||
+        "Unknown";
+      setTelegramUser(name);
       setTelegramId(tg.initDataUnsafe.user.id);
     }
   }, []);

--- a/app/telegram/page.tsx
+++ b/app/telegram/page.tsx
@@ -12,6 +12,7 @@ interface TelegramWebApp {
     user?: {
       id?: number;
       first_name?: string;
+      username?: string;
     };
   };
 }
@@ -34,7 +35,11 @@ export default function TelegramPage() {
     const tg = window.Telegram?.WebApp;
     if (tg) {
       tg.expand();
-      setTelegramUser(tg.initDataUnsafe?.user?.first_name);
+      const name =
+        tg.initDataUnsafe?.user?.username ||
+        tg.initDataUnsafe?.user?.first_name ||
+        "Unknown";
+      setTelegramUser(name);
       setTelegramId(tg.initDataUnsafe?.user?.id);
     }
   }, []);


### PR DESCRIPTION
## Summary
- add `username` to Telegram user type definition
- default to "Unknown" when Telegram user name is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b8fdc22883239c7c7884d3d6b704