### PR TITLE
fix: centralize Telegram types to avoid duplicate declarations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,25 +4,6 @@ import { useEffect, useState } from 'react';
 import { App as Framework7App, View } from 'framework7-react';
 import { Page, Navbar, Block, List, ListItem } from 'konsta/react';
 
-interface TelegramWebApp {
-  ready: () => void;
-  platform: string;
-  colorScheme?: string;
-  initDataUnsafe?: {
-    user?: {
-      id?: number;
-      first_name?: string;
-      last_name?: string;
-      username?: string;
-    };
-  };
-}
-
-declare global {
-  interface Window {
-    Telegram?: { WebApp?: TelegramWebApp };
-  }
-}
 
 export default function HomePage() {
   const [name, setName] = useState<string>('');

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -4,17 +4,6 @@ import { useEffect, useState } from 'react';
 import { App as Framework7App, View } from 'framework7-react';
 import { Page, Navbar, List, ListItem } from 'konsta/react';
 
-interface TelegramWebApp {
-  ready: () => void;
-  platform: string;
-  colorScheme?: string;
-}
-
-declare global {
-  interface Window {
-    Telegram?: { WebApp?: TelegramWebApp };
-  }
-}
 
 export default function SettingsPage() {
   const [platform, setPlatform] = useState<string>('unknown');

--- a/app/telegram/page.tsx
+++ b/app/telegram/page.tsx
@@ -7,24 +7,6 @@ import { Page, Navbar, Block, List, ListInput, Button } from "konsta/react";
 import { getSunSign } from "@/lib/astro";
 import { upsertProfile } from "@/lib/supabase";
 
-interface TelegramWebApp {
-  expand: () => void;
-  initDataUnsafe?: {
-    user?: {
-      id?: number;
-      first_name?: string;
-      last_name?: string;
-      username?: string;
-      photo_url?: string;
-    };
-  };
-}
-
-declare global {
-  interface Window {
-    Telegram?: { WebApp?: TelegramWebApp };
-  }
-}
 
 export default function TelegramPage() {
   const [telegramName, setTelegramName] = useState<string | undefined>();

--- a/types/telegram.d.ts
+++ b/types/telegram.d.ts
@@ -1,0 +1,23 @@
+export {};
+
+declare global {
+  interface TelegramWebApp {
+    ready: () => void;
+    expand: () => void;
+    platform: string;
+    colorScheme?: string;
+    initDataUnsafe?: {
+      user?: {
+        id?: number;
+        first_name?: string;
+        last_name?: string;
+        username?: string;
+        photo_url?: string;
+      };
+    };
+  }
+
+  interface Window {
+    Telegram?: { WebApp?: TelegramWebApp };
+  }
+}


### PR DESCRIPTION
## Summary
- centralize Telegram WebApp typings
- rely on shared type across home, settings and telegram pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d7f7eac483238595ce022c08fd17