### PR TITLE
Remove TMA SDK provider to avoid runtime crash

### DIFF
--- a/TELEGRAM_AUTH_README.md
+++ b/TELEGRAM_AUTH_README.md
@@ -35,18 +35,15 @@ types/
 В `app/layout.tsx` уже настроены провайдеры:
 
 ```tsx
-import { SDKProvider } from "@tma.js/sdk-react";
 import { TelegramAuthProvider } from "@/lib/telegram-auth";
 
 export default function RootLayout({ children }) {
   return (
     <html lang="ru">
       <body>
-        <SDKProvider>
-          <TelegramAuthProvider>
-            {children}
-          </TelegramAuthProvider>
-        </SDKProvider>
+        <TelegramAuthProvider>
+          {children}
+        </TelegramAuthProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Script from "next/script";
 import "./globals.css";
-import { SDKProvider } from "@tma.js/sdk-react";
 import { TelegramAuthProvider } from "@/lib/telegram-auth";
 
 export const metadata: Metadata = {
@@ -20,11 +19,9 @@ export default function RootLayout({
         <Script src="https://telegram.org/js/telegram-web-app.js" strategy="beforeInteractive" />
       </head>
       <body className="antialiased">
-        <SDKProvider>
-          <TelegramAuthProvider>
-            {children}
-          </TelegramAuthProvider>
-        </SDKProvider>
+        <TelegramAuthProvider>
+          {children}
+        </TelegramAuthProvider>
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "lucide-react": "^0.469.0",
     "framer-motion": "^11.0.0",
     "clsx": "^2.1.0",
-    "tailwind-merge": "^2.5.0",
-    "@tma.js/sdk-react": "^2.0.0",
-    "@tma.js/sdk": "^2.0.0"
+    "tailwind-merge": "^2.5.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- remove `@tma.js/sdk-react` provider from layout
- simplify Telegram auth to use `window.Telegram.WebApp`
- update docs and package to drop tma.js dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68910490b1e48323b1c5fa8f1a971592