### PR TITLE
feat: add Telegram main and settings pages with Supabase client

### DIFF
--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { App as Framework7App, View } from 'framework7-react';
+import { Page, Navbar, Block, List, ListItem } from 'konsta/react';
+import { useTelegramAuth } from '@/lib/telegram-auth';
+
+export default function MainPage() {
+  const { user, platform, colorScheme } = useTelegramAuth();
+
+  return (
+    <Framework7App theme={platform} className={colorScheme === 'dark' ? 'dark' : ''}>
+      <View main>
+        <Page>
+          <Navbar title="Главная" />
+          <Block strong>
+            {user ? (
+              <List>
+                <ListItem title="ID" after={user.id} />
+                <ListItem title="Имя" after={user.first_name} />
+                {user.username && (
+                  <ListItem title="Username" after={`@${user.username}`} />
+                )}
+              </List>
+            ) : (
+              <p>Данные пользователя недоступны</p>
+            )}
+          </Block>
+        </Page>
+      </View>
+    </Framework7App>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,31 +1,29 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { App as Framework7App, View } from 'framework7-react';
-import { Page, Navbar, List, ListItem } from 'konsta/react';
-
+import { Page, Navbar, List, ListItem, Toggle } from 'konsta/react';
+import { useTelegramAuth } from '@/lib/telegram-auth';
 
 export default function SettingsPage() {
-  const [platform, setPlatform] = useState<string>('unknown');
-  const [colorScheme, setColorScheme] = useState<'light' | 'dark'>('light');
-
-  useEffect(() => {
-    const tg = window.Telegram?.WebApp;
-    if (tg) {
-      tg.ready();
-      setPlatform(tg.platform);
-      setColorScheme(tg.colorScheme === 'dark' ? 'dark' : 'light');
-    }
-  }, []);
+  const { platform, colorScheme } = useTelegramAuth();
+  const [scheme, setScheme] = useState<'light' | 'dark'>(colorScheme);
 
   return (
-    <Framework7App theme={platform === 'ios' ? 'ios' : 'md'} className={colorScheme === 'dark' ? 'dark' : ''}>
+    <Framework7App theme={platform} className={scheme === 'dark' ? 'dark' : ''}>
       <View main>
         <Page>
           <Navbar title="Настройки" />
           <List strong inset>
-            <ListItem title="Платформа" after={platform} />
-            <ListItem title="Тема" after={colorScheme} />
+            <ListItem
+              title="Тёмная тема"
+              after={
+                <Toggle
+                  checked={scheme === 'dark'}
+                  onChange={(e) => setScheme(e.target.checked ? 'dark' : 'light')}
+                />
+              }
+            />
           </List>
         </Page>
       </View>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.5.0",
     "@tma.js/sdk-react": "^2.0.0",
-    "@tma.js/sdk": "^2.0.0"
+    "@tma.js/sdk": "^2.0.0",
+    "@supabase/supabase-js": "^2.44.0"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -35,6 +36,8 @@
     "@tailwindcss/typography": "^0.5.13",
     "eslint": "^9",
     "eslint-config-next": "14.1.0",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31"
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+    autoprefixer: {},
+  },
 };
 
 export default config;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,3 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);
+
 export interface ProfileData {
   id: string;
   birth_date: string;
@@ -5,24 +12,14 @@ export interface ProfileData {
   birth_place: string;
 }
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const SUPABASE_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-
 export async function upsertProfile(data: ProfileData) {
-  const res = await fetch(`${SUPABASE_URL}/rest/v1/profiles`, {
-    method: "POST",
-    headers: {
-      apikey: SUPABASE_KEY,
-      Authorization: `Bearer ${SUPABASE_KEY}`,
-      "Content-Type": "application/json",
-      Prefer: "resolution=merge-duplicates",
-    },
-    body: JSON.stringify(data),
-  });
+  const { data: result, error } = await supabase
+    .from('profiles')
+    .upsert(data, { onConflict: 'id' });
 
-  if (!res.ok) {
-    throw new Error(`Supabase error: ${res.status}`);
+  if (error) {
+    throw error;
   }
 
-  return res.json();
+  return result;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,7 @@ import forms from "@tailwindcss/forms";
 import typography from "@tailwindcss/typography";
 
 const config = konstaConfig({
+  darkMode: "class",
   content: ["./src/**/*.{js,ts,jsx,tsx}", "./app/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- add Supabase client initialization and profile upsert helper
- configure Tailwind dark mode and PostCSS autoprefixer
- implement MainPage showing Telegram user info
- add theme toggle to SettingsPage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689106faba448323964898ff9241f550