### PR TITLE
Add natal chart form and routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,71 +1,11 @@
-import React, { useState } from 'react';
-import StartScreen from './components/StartScreen';
-import NatalForm from './components/NatalForm';
-import NatalChart from './components/NatalChart';
-import NavMenu from './components/NavMenu';
-import StarField from './components/StarField';
-
-const translations = {
-  ru: {
-    appName: 'Astrot',
-    buildChart: 'Построить натальную карту',
-    name: 'Имя',
-    birthDate: 'Дата рождения',
-    birthPlace: 'Место рождения',
-    submit: 'Показать карту',
-    chartPlaceholder: 'Здесь будет твоя натальная карта',
-    home: 'Главная',
-    profile: 'Профиль',
-    about: 'О приложении',
-  },
-  en: {
-    appName: 'Astrot',
-    buildChart: 'Build natal chart',
-    name: 'Name',
-    birthDate: 'Birth date',
-    birthPlace: 'Birth place',
-    submit: 'Show chart',
-    chartPlaceholder: 'Your natal chart will appear here',
-    home: 'Home',
-    profile: 'Profile',
-    about: 'About',
-  },
-};
+import React from 'react';
+import { App as KonstaApp, View } from 'konsta/react';
+import routes from './routes.js';
 
 export default function App() {
-  const [lang, setLang] = useState<'ru' | 'en'>('ru');
-  const [screen, setScreen] = useState<'start' | 'form' | 'chart'>('start');
-  const t = translations[lang];
-
   return (
-    <div className="relative min-h-screen bg-gradient-to-b from-purple-900 via-indigo-900 to-black text-white">
-      <StarField />
-      <div className="relative z-10 flex flex-col min-h-screen">
-        <div className="flex justify-end p-4">
-          <button
-            onClick={() => setLang(lang === 'ru' ? 'en' : 'ru')}
-            className="text-sm uppercase"
-          >
-            {lang === 'ru' ? 'EN' : 'RU'}
-          </button>
-        </div>
-        <div className="flex-1">
-          {screen === 'start' && (
-            <StartScreen
-              title={t.appName}
-              button={t.buildChart}
-              onStart={() => setScreen('form')}
-            />
-          )}
-          {screen === 'form' && (
-            <NatalForm t={t} onSubmit={() => setScreen('chart')} />
-          )}
-          {screen === 'chart' && (
-            <NatalChart placeholder={t.chartPlaceholder} />
-          )}
-        </div>
-        <NavMenu t={t} />
-      </div>
-    </div>
+    <KonstaApp theme="ios" routes={routes}>
+      <View main url="/" />
+    </KonstaApp>
   );
 }

--- a/src/components/KoteusAstrolog.jsx
+++ b/src/components/KoteusAstrolog.jsx
@@ -1,0 +1,11 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+export default function KoteusAstrolog({ message = 'Мяу! Я Котеус, помогу построить натальную карту.', error }) {
+  return (
+    <div className="flex items-center space-x-4 mb-4">
+      <div className="text-5xl">🐱‍🔬</div>
+      <div className={`text-lg ${error ? 'text-red-400' : ''}`}>{error || message}</div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,26 @@
     transform: scale(1.2);
   }
 }
+
+.glassy {
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 1rem;
+}
+
+.neon-btn {
+  background: linear-gradient(90deg, #ff00ff, #00ffff);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  box-shadow: 0 0 10px #ff00ff, 0 0 20px #00ffff;
+}
+
+.neon-input input {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+}

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Page, Navbar, Block, Button } from 'konsta/react';
+
+export default function MainPage() {
+  return (
+    <Page>
+      <Navbar title="Astrot" />
+      <Block strong className="text-center mt-8">
+        <Button href="/natal-form/" className="neon-btn">Построить натальную карту</Button>
+      </Block>
+    </Page>
+  );
+}

--- a/src/pages/NatalFormPage.jsx
+++ b/src/pages/NatalFormPage.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Page, Navbar, List, ListInput, Button } from 'konsta/react';
+import { useRouter } from 'framework7-react';
+import KoteusAstrolog from '../components/KoteusAstrolog.jsx';
+
+export default function NatalFormPage() {
+  const router = useRouter();
+  const [formData, setFormData] = useState({ name: '', date: '', time: '', city: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!formData.name || !formData.date || !formData.time || !formData.city) {
+      setError('Мяу! Заполни все поля.');
+      return;
+    }
+    setError('');
+    router.navigate('/natal-result/', { props: { data: formData } });
+  };
+
+  return (
+    <Page className="p-4">
+      <Navbar title="Форма" />
+      <KoteusAstrolog error={error} />
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <List className="neon-input">
+          <ListInput
+            label="Имя"
+            name="name"
+            type="text"
+            placeholder="Имя"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
+          <ListInput
+            label="Дата рождения"
+            name="date"
+            type="date"
+            placeholder="Дата"
+            value={formData.date}
+            onChange={handleChange}
+            required
+          />
+          <ListInput
+            label="Время рождения"
+            name="time"
+            type="time"
+            placeholder="Время"
+            value={formData.time}
+            onChange={handleChange}
+            required
+          />
+          <ListInput
+            label="Город рождения"
+            name="city"
+            type="text"
+            placeholder="Город"
+            value={formData.city}
+            onChange={handleChange}
+            required
+          />
+        </List>
+        <Button type="submit" className="neon-btn w-full">Построить натальную карту</Button>
+      </form>
+    </Page>
+  );
+}

--- a/src/pages/NatalResultPage.jsx
+++ b/src/pages/NatalResultPage.jsx
@@ -1,0 +1,36 @@
+/* eslint-disable react/prop-types */
+import React, { useEffect, useState } from 'react';
+import { Page, Navbar, Block } from 'konsta/react';
+
+export default function NatalResultPage({ data }) {
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    async function fetchNatal() {
+      // Здесь в будущем можно вызвать внешний API, передав данные формы.
+      // Пример:
+      // const response = await fetch('YOUR_API_URL', {
+      //   method: 'POST',
+      //   headers: { 'Content-Type': 'application/json' },
+      //   body: JSON.stringify(data),
+      // });
+      // const json = await response.json();
+      // setResult(json);
+      setResult(null);
+    }
+    fetchNatal();
+  }, [data]);
+
+  return (
+    <Page>
+      <Navbar title="Результат" />
+      <Block strong>
+        {result ? (
+          <pre>{JSON.stringify(result, null, 2)}</pre>
+        ) : (
+          'Здесь будет результат натальной карты'
+        )}
+      </Block>
+    </Page>
+  );
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,20 @@
+import MainPage from './pages/MainPage.jsx';
+import NatalFormPage from './pages/NatalFormPage.jsx';
+import NatalResultPage from './pages/NatalResultPage.jsx';
+
+const routes = [
+  {
+    path: '/',
+    component: MainPage,
+  },
+  {
+    path: '/natal-form/',
+    component: NatalFormPage,
+  },
+  {
+    path: '/natal-result/',
+    component: NatalResultPage,
+  },
+];
+
+export default routes;


### PR DESCRIPTION
## Summary
- add Koteus Astrolog component with dynamic messages
- create neon glass natal form and result pages
- wire Framework7 routes and main navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6891d3e7428883239d30864b6e38e753