### PR TITLE
Fix duplicated screen and add Telegram user info

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,16 +3,14 @@
 @tailwind utilities;
 
 /* Telegram Web App Fullscreen Styles */
-html, body {
+html, body, #root {
+  width: 100%;
   height: 100vh;
-  overflow-x: hidden;
+  height: var(--tg-viewport-height, 100vh);
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
   background: #0f0f23;
-}
-
-/* Ensure fullscreen mode works properly */
-#root {
-  height: 100vh;
-  width: 100vw;
 }
 
 /* Hide scrollbars but keep functionality */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,5 @@ import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <App />
 );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -26,22 +26,22 @@ export default function MainPage() {
   ];
 
   return (
-    <Page className="cosmic-bg relative overflow-hidden text-center min-h-screen">
+    <Page className="cosmic-bg relative overflow-hidden text-center h-screen">
       <StarField />
       {loading ? (
         <SplashScreen />
       ) : (
-        <div className="relative z-10 pt-8 px-4">
-          <TelegramUserInfo />
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-yellow-300 to-orange-400 bg-clip-text text-transparent mb-2">
+        <div className="relative z-10 pt-4 px-4">
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-yellow-300 to-orange-400 bg-clip-text text-transparent mb-1">
             ASTROT
           </h1>
-          <p className="text-white/90 mb-4">Твой магический проводник в космос 🌟</p>
+          <p className="text-white/90 mb-2">Твой магический проводник в космос 🌟</p>
           <MagicCat />
+          <TelegramUserInfo />
           <div className="koteus-message">
             Мяу! Я Котеус - твой космический проводник! Погладь меня и выбери, что тебя интересует! ✨
           </div>
-          <div className="grid grid-cols-2 gap-4 mt-6 max-w-md mx-auto">
+          <div className="grid grid-cols-2 gap-4 mt-4 max-w-md mx-auto">
             {menu.map((item) => (
               <div
                 key={item.name}


### PR DESCRIPTION
## Summary
- avoid double rendering by removing React.StrictMode
- use Telegram viewport height for true fullscreen and hide scroll
- show Telegram user info under the cat on the main page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 925 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892868d041083239ce1307cfbe4831d