### PR TITLE
fix: handle Telegram expand after ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,14 +10,46 @@
     <title>ASTROT - Космическая Астрология с Котеусом</title>
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <script>
-      document.addEventListener('DOMContentLoaded', function() {
+      document.addEventListener('DOMContentLoaded', function () {
         const tg = window.Telegram?.WebApp;
-        if (tg) {
-          tg.expand();
-          if (tg.isExpanded) {
-            console.log('Приложение развернуто');
+        if (!tg) return;
+
+        // Сообщаем, что приложение готово
+        tg.ready();
+
+        // Диагностическая информация
+        console.log('Версия:', tg.version);
+        console.log('Платформа:', tg.platform);
+        console.log('Высота до expand:', tg.viewportHeight);
+
+        const expandApp = () => {
+          if (!tg.isExpanded) {
+            console.log('Пытаюсь развернуть...');
+            tg.expand();
+          } else {
+            console.log('Уже развернуто!');
           }
+
+          setTimeout(() => {
+            console.log('Высота после expand:', tg.viewportHeight);
+            console.log('isExpanded:', tg.isExpanded);
+          }, 100);
+        };
+
+        // На мобильных платформах ждем немного
+        if (tg.platform === 'ios' || tg.platform === 'android') {
+          setTimeout(expandApp, 50);
+        } else {
+          expandApp();
         }
+
+        // Отслеживаем изменение viewport
+        tg.onEvent('viewportChanged', function () {
+          console.log('Viewport изменен!');
+          console.log('Новая высота:', tg.viewportHeight);
+          console.log('Стабильная высота:', tg.viewportStableHeight);
+          console.log('isExpanded сейчас:', tg.isExpanded);
+        });
       });
     </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/framework7@8.0.0/css/framework7-bundle.css">

--- a/src/index.css
+++ b/src/index.css
@@ -3,15 +3,20 @@
 @tailwind utilities;
 
 /* Telegram Web App Fullscreen Styles */
-html, body, #root {
+html, body {
   width: 100%;
-  min-height: 100vh;
-  min-height: var(--tg-viewport-height, 100vh);
   margin: 0;
   padding: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
+  height: 100%;
+  overflow: hidden;
   background: #0f0f23;
+}
+
+#root {
+  width: 100%;
+  height: 100vh;
+  height: var(--tg-viewport-height, 100vh);
+  overflow-y: auto;
 }
 
 

--- a/src/lib/telegram-init.js
+++ b/src/lib/telegram-init.js
@@ -17,12 +17,48 @@ export const initTelegramSDK = () => {
   try {
     // Initialize Telegram WebApp
     const webApp = window.Telegram.WebApp;
+
+    // Сообщаем о готовности
     webApp.ready();
+
+    // Диагностическая информация
+    console.log('Версия:', webApp.version);
+    console.log('Платформа:', webApp.platform);
+    console.log('Высота до expand:', webApp.viewportHeight);
+
+    const expandApp = () => {
+      if (!webApp.isExpanded) {
+        console.log('Пытаюсь развернуть...');
+        webApp.expand();
+      } else {
+        console.log('Уже развернуто!');
+      }
+
+      setTimeout(() => {
+        console.log('Высота после expand:', webApp.viewportHeight);
+        console.log('isExpanded:', webApp.isExpanded);
+      }, 100);
+    };
+
+    // На мобильных платформах немного ждем
+    if (webApp.platform === 'ios' || webApp.platform === 'android') {
+      setTimeout(expandApp, 50);
+    } else {
+      expandApp();
+    }
+
+    // Отслеживаем изменение viewport
+    webApp.onEvent('viewportChanged', () => {
+      console.log('Viewport изменен!');
+      console.log('Новая высота:', webApp.viewportHeight);
+      console.log('Стабильная высота:', webApp.viewportStableHeight);
+      console.log('isExpanded сейчас:', webApp.isExpanded);
+    });
 
     // Set theme colors
     webApp.setHeaderColor('#1a1a2e');
     webApp.setBackgroundColor('#0f0f23');
-    
+
     return webApp;
   } catch (error) {
     console.error('Failed to initialize Telegram SDK:', error);


### PR DESCRIPTION
## Summary
- ensure Telegram Mini App waits for readiness before calling `expand`
- log platform and viewport info and attach `viewportChanged` listener
- apply Telegram-specific full screen CSS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68928cb7920883239ea6ed3f570e6d4f