### PR TITLE
Add Telegram WebApp fullscreen support

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
           setTimeout(() => {
             console.log('Высота после expand:', tg.viewportHeight);
             console.log('isExpanded:', tg.isExpanded);
+            if (!tg.isFullscreen) {
+              console.log('Запрашиваю fullscreen...');
+              tg.requestFullscreen();
+            }
           }, 100);
         };
 
@@ -42,6 +46,15 @@
         } else {
           expandApp();
         }
+
+        tg.onEvent('fullscreen_changed', function () {
+          console.log('Fullscreen изменен:', tg.isFullscreen);
+          document.body.classList.toggle('fullscreen', tg.isFullscreen);
+        });
+
+        tg.onEvent('fullscreen_failed', function (params) {
+          console.error('Fullscreen не удался:', params.error);
+        });
 
         // Отслеживаем изменение viewport
         tg.onEvent('viewportChanged', function () {
@@ -55,7 +68,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/framework7@8.0.0/css/framework7-bundle.css">
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root" class="app-container"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -12,9 +12,16 @@ html, body {
   background: #0f0f23;
 }
 
-#root {
-  width: 100%;
+body.fullscreen {
+  margin: 0;
+  padding: 0;
   height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.app-container {
+  width: 100%;
   height: var(--tg-viewport-height, 100vh);
   overflow-y: auto;
 }

--- a/src/lib/telegram-init.js
+++ b/src/lib/telegram-init.js
@@ -37,6 +37,11 @@ export const initTelegramSDK = () => {
       setTimeout(() => {
         console.log('Высота после expand:', webApp.viewportHeight);
         console.log('isExpanded:', webApp.isExpanded);
+
+        if (!webApp.isFullscreen) {
+          console.log('Запрашиваю fullscreen...');
+          webApp.requestFullscreen();
+        }
       }, 100);
     };
 
@@ -46,6 +51,16 @@ export const initTelegramSDK = () => {
     } else {
       expandApp();
     }
+
+    // Отслеживаем изменение fullscreen
+    webApp.onEvent('fullscreen_changed', () => {
+      console.log('Fullscreen изменен:', webApp.isFullscreen);
+      document.body.classList.toggle('fullscreen', webApp.isFullscreen);
+    });
+
+    webApp.onEvent('fullscreen_failed', (params) => {
+      console.error('Fullscreen не удался:', params.error);
+    });
 
     // Отслеживаем изменение viewport
     webApp.onEvent('viewportChanged', () => {
@@ -144,5 +159,28 @@ export const mockTelegramWebApp = () => {
         }
       }
     };
+  }
+};
+
+export const checkFullscreen = () => {
+  const tg = window.Telegram?.WebApp;
+  if (!tg) return;
+
+  console.log('=== FULLSCREEN ДИАГНОСТИКА ===');
+  console.log('isExpanded:', tg.isExpanded);
+  console.log('isFullscreen:', tg.isFullscreen);
+  console.log('viewportHeight:', tg.viewportHeight);
+  console.log('viewportStableHeight:', tg.viewportStableHeight);
+
+  if (!tg.isFullscreen) {
+    console.log('Пытаюсь войти в fullscreen...');
+    tg.requestFullscreen();
+    setTimeout(() => {
+      console.log('=== ПОСЛЕ FULLSCREEN ===');
+      console.log('isFullscreen теперь:', tg.isFullscreen);
+      console.log('viewportHeight теперь:', tg.viewportHeight);
+    }, 500);
+  } else {
+    console.log('Уже в fullscreen режиме');
   }
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -14,6 +14,19 @@ export default function MainPage() {
     return () => clearTimeout(timer);
   }, []);
 
+  const enterFullscreen = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tg = (window as any).Telegram?.WebApp;
+    if (tg && !tg.isFullscreen) {
+      tg.requestFullscreen();
+    }
+  };
+
+  const exitFullscreen = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).Telegram?.WebApp?.exitFullscreen();
+  };
+
   const menu = [
     { name: 'natal', icon: '🔮', title: 'Натальная карта' },
     { name: 'tarot', icon: '🎴', title: 'Таро' },
@@ -38,6 +51,14 @@ export default function MainPage() {
           <p className="text-white/90 mb-2">Твой магический проводник в космос 🌟</p>
           <MagicCat />
           <TelegramUserInfo />
+          <div className="flex justify-center gap-2 mb-4">
+            <button id="fullscreenBtn" className="neon-btn" onClick={enterFullscreen}>
+              Полный экран
+            </button>
+            <button id="exitFullscreenBtn" className="neon-btn" onClick={exitFullscreen}>
+              Выйти из полного экрана
+            </button>
+          </div>
           <div className="koteus-message">
             Мяу! Я Котеус - твой космический проводник! Погладь меня и выбери, что тебя интересует! ✨
           </div>


### PR DESCRIPTION
## Summary
- request fullscreen for Telegram WebApp and handle fullscreen events
- add CSS and buttons to manage fullscreen mode
- include diagnostic helper for fullscreen state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68928f45074483239d05caaa77a83fcf