### PR TITLE
Add debug utilities for infinite scroll and data flow

### DIFF
--- a/src/components/InfiniteScroll.tsx
+++ b/src/components/InfiniteScroll.tsx
@@ -1,0 +1,71 @@
+import React, { useRef, useState, useCallback, useEffect } from 'react';
+
+interface InfiniteScrollProps {
+  children: React.ReactNode;
+  onLoadMore?: () => void;
+  hasMore: boolean;
+  loading: boolean;
+}
+
+const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
+  children,
+  onLoadMore,
+  hasMore,
+  loading,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const loadingRef = useRef(false);
+
+  console.log('♾️ InfiniteScroll RENDER:', {
+    hasMore,
+    loading,
+    childrenCount: React.Children.count(children),
+    scrollPosition,
+  });
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+      const currentPosition = scrollTop;
+      const isNearBottom = scrollTop + clientHeight >= scrollHeight - 100;
+
+      console.log('📜 SCROLL EVENT:', {
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+        isNearBottom,
+        hasMore,
+        loading: loadingRef.current,
+        timestamp: Date.now(),
+      });
+
+      setScrollPosition(currentPosition);
+
+      if (isNearBottom && hasMore && !loadingRef.current) {
+        console.log('🔽 TRIGGERING LOAD MORE');
+        loadingRef.current = true;
+        onLoadMore?.();
+      }
+    },
+    [hasMore, onLoadMore]
+  );
+
+  useEffect(() => {
+    loadingRef.current = loading;
+    console.log('🔄 Loading state changed:', loading);
+  }, [loading]);
+
+  return (
+    <div
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className="infinite-scroll-container"
+      style={{ height: '100vh', overflowY: 'auto' }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default InfiniteScroll;

--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -1,0 +1,50 @@
+import React, { useRef } from 'react';
+
+interface Item {
+  id: string;
+  text?: string;
+}
+
+interface ItemsListProps {
+  items: Item[];
+  onLoadMore?: () => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ItemsList: React.FC<ItemsListProps> = ({ items, onLoadMore }) => {
+  const renderCount = useRef(0);
+  renderCount.current++;
+
+  console.log('📋 ItemsList RENDER:', {
+    renderNumber: renderCount.current,
+    itemsCount: items?.length || 0,
+    itemsIds: items?.map((item) => item.id).slice(0, 5) || [],
+    timestamp: Date.now(),
+  });
+
+  // Duplicate check
+  const duplicates =
+    items?.filter(
+      (item, index) => items.findIndex((i) => i.id === item.id) !== index
+    ) || [];
+
+  if (duplicates.length > 0) {
+    console.error('🚨 DUPLICATE ITEMS FOUND:', duplicates.map((d) => d.id));
+  }
+
+  return (
+    <div className="items-list">
+      {items?.map((item, index) => (
+        <div
+          key={`${item.id}-${index}`}
+          className="item"
+          data-id={item.id}
+        >
+          {item.text || item.id}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ItemsList;

--- a/src/hooks/useInfiniteData.ts
+++ b/src/hooks/useInfiniteData.ts
@@ -1,0 +1,71 @@
+import { useState, useCallback } from 'react';
+
+interface Item {
+  id: string;
+  text?: string;
+}
+
+// Simulated async data fetcher
+const fetchData = async (page: number): Promise<Item[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return Array.from({ length: 20 }, (_, i) => ({
+    id: `item-${page}-${i}`,
+    text: `Item ${page}-${i}`,
+  }));
+};
+
+const useInfiniteData = () => {
+  const [data, setData] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  console.log('💾 useInfiniteData STATE:', {
+    dataLength: data.length,
+    loading,
+    page,
+    hasMore,
+    firstItems: data.slice(0, 3).map((item) => item.id),
+  });
+
+  const loadMore = useCallback(async () => {
+    if (loading) {
+      console.log('⏸️ Already loading, skipping...');
+      return;
+    }
+
+    console.log('📥 LOADING MORE DATA:', { currentPage: page });
+    setLoading(true);
+
+    try {
+      const newData = await fetchData(page);
+      console.log('✅ DATA LOADED:', {
+        page,
+        newItemsCount: newData.length,
+        newItemsIds: newData.map((item) => item.id),
+        totalItemsAfter: data.length + newData.length,
+      });
+
+      setData((prevData) => {
+        const combined = [...prevData, ...newData];
+        console.log('🔀 COMBINING DATA:', {
+          prevCount: prevData.length,
+          newCount: newData.length,
+          combinedCount: combined.length,
+        });
+        return combined;
+      });
+
+      setPage((prev) => prev + 1);
+      setHasMore(newData.length > 0);
+    } catch (error) {
+      console.error('❌ LOADING ERROR:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [data, loading, page]);
+
+  return { data, loading, hasMore, loadMore };
+};
+
+export default useInfiniteData;

--- a/src/pages/InfiniteScrollPage.tsx
+++ b/src/pages/InfiniteScrollPage.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import { Page } from 'konsta/react';
+import InfiniteScroll from '../components/InfiniteScroll';
+import ItemsList from '../components/ItemsList';
+import useInfiniteData from '../hooks/useInfiniteData';
+import { logDOMStructure } from '../utils/logDOMStructure';
+
+const InfiniteScrollPage: React.FC = () => {
+  const { data, loading, hasMore, loadMore } = useInfiniteData();
+
+  console.log('🚀 APP RENDER:', {
+    timestamp: new Date().toISOString(),
+    dataCount: data.length,
+    loading,
+    hasMore,
+  });
+
+  useEffect(() => {
+    const interval = setInterval(logDOMStructure, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <Page className="app">
+      <InfiniteScroll onLoadMore={loadMore} hasMore={hasMore} loading={loading}>
+        <ItemsList items={data} onLoadMore={loadMore} />
+        {loading && <div className="loading">Загрузка...</div>}
+      </InfiniteScroll>
+    </Page>
+  );
+};
+
+export default InfiniteScrollPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -9,6 +9,22 @@ export default function MainPage() {
   const [loading, setLoading] = useState(true);
   const [modal, setModal] = useState<string | null>(null);
 
+  // ==== DEBUG RENDER LOGS ====
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderCount = ((window as any).mainPageRenderCount =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ((window as any).mainPageRenderCount || 0) + 1);
+  console.log('🔄 MainPage RENDER:', {
+    timestamp: new Date().toISOString(),
+    renderCount,
+  });
+
+  // Log component mount/unmount
+  useEffect(() => {
+    console.log('📱 MainPage MOUNTED');
+    return () => console.log('💀 MainPage UNMOUNTED');
+  }, []);
+
   useEffect(() => {
     const timer = setTimeout(() => setLoading(false), 3000);
     return () => clearTimeout(timer);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import MainPage from './pages/MainPage.tsx';
 import NatalFormPage from './pages/NatalFormPage.jsx';
 import NatalResultPage from './pages/NatalResultPage.jsx';
 import SettingsPage from './pages/SettingsPage.jsx';
+import InfiniteScrollPage from './pages/InfiniteScrollPage.tsx';
 
 const routes = [
   {
@@ -19,6 +20,10 @@ const routes = [
   {
     path: '/settings/',
     component: SettingsPage,
+  },
+  {
+    path: '/debug-scroll/',
+    component: InfiniteScrollPage,
   },
 ];
 

--- a/src/utils/logDOMStructure.ts
+++ b/src/utils/logDOMStructure.ts
@@ -1,0 +1,27 @@
+export const logDOMStructure = () => {
+  console.log('🏗 DOM STRUCTURE CHECK:');
+
+  const containers = document.querySelectorAll(
+    '[class*="container"], [class*="page"], [class*="scroll"]'
+  );
+  containers.forEach((el, index) => {
+    console.log(`Container ${index}:`, {
+      className: (el as HTMLElement).className,
+      id: (el as HTMLElement).id,
+      childrenCount: el.children.length,
+      scrollHeight: (el as HTMLElement).scrollHeight,
+      clientHeight: (el as HTMLElement).clientHeight,
+      scrollTop: (el as HTMLElement).scrollTop,
+    });
+  });
+
+  const allItems = document.querySelectorAll('[class*="item"]');
+  const itemIds = Array.from(allItems).map((el) =>
+    (el as HTMLElement).dataset.id || el.textContent?.slice(0, 20) || ''
+  );
+  const duplicateIds = itemIds.filter((id, index) => itemIds.indexOf(id) !== index);
+
+  if (duplicateIds.length > 0) {
+    console.error('🚨 DUPLICATE DOM ELEMENTS:', duplicateIds);
+  }
+};


### PR DESCRIPTION
## Summary
- instrument MainPage with render lifecycle logs
- introduce reusable InfiniteScroll, ItemsList and data hook with detailed logging
- add DOM structure logger and demo page for infinite scroll debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929273b7c48323b54ecbe08dbf6c12