### PR TITLE
Add app initialization diagnostics and duplicate start guard

### DIFF
--- a/src/components/TelegramWrapper.jsx
+++ b/src/components/TelegramWrapper.jsx
@@ -1,23 +1,29 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { mockTelegramWebApp, isTelegramWebApp, initTelegramSDK } from '../lib/telegram-init';
 
 export default function TelegramWrapper({ children }) {
   const [isInitialized, setIsInitialized] = useState(false);
   const [error, setError] = useState(null);
+  const cleanupRef = useRef(null);
 
   useEffect(() => {
+    console.log('🎯 Запускаем инициализацию App');
     try {
       // Initialize mock Telegram WebApp for development
       if (!isTelegramWebApp()) {
         mockTelegramWebApp();
       }
-      
+
       // Initialize Telegram SDK
-      const webApp = initTelegramSDK();
-      if (webApp) {
+      const result = initTelegramSDK();
+      if (result) {
         console.log('Telegram WebApp initialized successfully');
+        window.telegramInitialized = true;
+        if (typeof result === 'function') {
+          cleanupRef.current = result;
+        }
       }
-      
+
       setIsInitialized(true);
     } catch (err) {
       console.error('Failed to initialize Telegram wrapper:', err);
@@ -25,6 +31,12 @@ export default function TelegramWrapper({ children }) {
       // Still set as initialized to prevent infinite loading
       setIsInitialized(true);
     }
+
+    return () => {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+      }
+    };
   }, []);
 
   // Show loading state while initializing

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,43 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
+declare global {
+  interface Window {
+    appStarted?: boolean;
+    telegramInitialized?: boolean;
+    htmlReady?: unknown;
+    Telegram?: {
+      WebApp?: unknown;
+    };
+  }
+}
+
+// Prevent duplicate app initialization
+if (window.appStarted) {
+  console.error('🚨 App уже запущен! Предотвращаем дублирование');
+  throw new Error('Duplicate app initialization prevented');
+}
+window.appStarted = true;
+
+// Ensure telegramInitialized flag exists for diagnostics
+if (typeof window.telegramInitialized === 'undefined') {
+  window.telegramInitialized = false;
+}
+
+// Additional logs for diagnostics
+const logExecutionContext = () => {
+  console.log('🔍 Execution Context:', {
+    location: 'React Bundle',
+    telegramInitialized: window.telegramInitialized,
+    htmlReady: window.htmlReady,
+    telegramAPI: Boolean(window.Telegram?.WebApp),
+    timestamp: new Date().toISOString(),
+  });
+};
+
+// Log execution context immediately
+logExecutionContext();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <App />
 );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Page, Popup } from 'konsta/react';
 import StarField from '../components/StarField';
 import MagicCat from '../components/MagicCat';
@@ -10,18 +10,21 @@ export default function MainPage() {
   const [modal, setModal] = useState<string | null>(null);
 
   // ==== DEBUG RENDER LOGS ====
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const renderCount = ((window as any).mainPageRenderCount =
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ((window as any).mainPageRenderCount || 0) + 1);
+  const renderCount = useRef(0);
+  const [isMounted, setIsMounted] = useState(false);
+
+  renderCount.current++;
+
   console.log('🔄 MainPage RENDER:', {
+    renderCount: renderCount.current,
     timestamp: new Date().toISOString(),
-    renderCount,
+    isMounted,
   });
 
   // Log component mount/unmount
   useEffect(() => {
     console.log('📱 MainPage MOUNTED');
+    setIsMounted(true);
     return () => console.log('💀 MainPage UNMOUNTED');
   }, []);
 
@@ -55,7 +58,7 @@ export default function MainPage() {
   ];
 
   return (
-    <Page className="cosmic-bg relative overflow-hidden text-center h-screen">
+    <Page className="cosmic-bg relative text-center min-h-screen overflow-y-auto">
       <StarField />
       {loading ? (
         <SplashScreen />
@@ -89,6 +92,9 @@ export default function MainPage() {
                 <span className="menu-title">{item.title}</span>
               </div>
             ))}
+          </div>
+          <div className="debug-info text-xs mt-2 text-white/50">
+            <small>Renders: {renderCount.current}</small>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- prevent multiple app startups and add execution context logging
- track MainPage render/mount counts and show debug info while allowing scroll
- enhance Telegram wrapper with startup logging and optional cleanup hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689295a8268883238a441bf51d09a75a