### PR TITLE
fix: prevent duplicate execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,62 +9,6 @@
     <meta name="format-detection" content="telephone=no" />
     <title>ASTROT - Космическая Астрология с Котеусом</title>
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        const tg = window.Telegram?.WebApp;
-        if (!tg) return;
-
-        // Сообщаем, что приложение готово
-        tg.ready();
-
-        // Диагностическая информация
-        console.log('Версия:', tg.version);
-        console.log('Платформа:', tg.platform);
-        console.log('Высота до expand:', tg.viewportHeight);
-
-        const expandApp = () => {
-          if (!tg.isExpanded) {
-            console.log('Пытаюсь развернуть...');
-            tg.expand();
-          } else {
-            console.log('Уже развернуто!');
-          }
-
-          setTimeout(() => {
-            console.log('Высота после expand:', tg.viewportHeight);
-            console.log('isExpanded:', tg.isExpanded);
-            if (!tg.isFullscreen) {
-              console.log('Запрашиваю fullscreen...');
-              tg.requestFullscreen();
-            }
-          }, 100);
-        };
-
-        // На мобильных платформах ждем немного
-        if (tg.platform === 'ios' || tg.platform === 'android') {
-          setTimeout(expandApp, 50);
-        } else {
-          expandApp();
-        }
-
-        tg.onEvent('fullscreen_changed', function () {
-          console.log('Fullscreen изменен:', tg.isFullscreen);
-          document.body.classList.toggle('fullscreen', tg.isFullscreen);
-        });
-
-        tg.onEvent('fullscreen_failed', function (params) {
-          console.error('Fullscreen не удался:', params.error);
-        });
-
-        // Отслеживаем изменение viewport
-        tg.onEvent('viewportChanged', function () {
-          console.log('Viewport изменен!');
-          console.log('Новая высота:', tg.viewportHeight);
-          console.log('Стабильная высота:', tg.viewportStableHeight);
-          console.log('isExpanded сейчас:', tg.isExpanded);
-        });
-      });
-    </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/framework7@8.0.0/css/framework7-bundle.css">
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,32 @@ import React, { useEffect, useState } from 'react';
 import { App as KonstaApp } from 'konsta/react';
 import { App as F7App, View } from 'framework7-react';
 import routes from './routes.tsx';
-import TelegramWrapper from './components/TelegramWrapper';
 import ErrorBoundary from './components/ErrorBoundary';
 import Framework7 from 'framework7/lite-bundle';
 import Framework7React from 'framework7-react';
+import { useTelegramWebApp } from './hooks/useTelegramWebApp';
+
+declare global {
+  interface Window {
+    APP_INSTANCE_EXISTS?: boolean;
+  }
+}
 
 // Register Framework7 React plugin (required for Framework7 components to work correctly)
 Framework7.use(Framework7React);
 
 export default function App() {
+  if (window.APP_INSTANCE_EXISTS) {
+    console.error('🚨 App уже запущен! Блокируем дублирование');
+    return null;
+  }
+  window.APP_INSTANCE_EXISTS = true;
+
+  console.log('🎯 APP COMPONENT RENDER');
+
   const [dark, setDark] = useState(false);
+
+  useTelegramWebApp();
 
   useEffect(() => {
     const saved = localStorage.getItem('theme') === 'dark';
@@ -24,13 +40,11 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <TelegramWrapper>
-        <KonstaApp theme="ios" dark={dark}>
-          <F7App theme="ios" routes={routes}>
-            <View main url="/" />
-          </F7App>
-        </KonstaApp>
-      </TelegramWrapper>
+      <KonstaApp theme="ios" dark={dark}>
+        <F7App theme="ios" routes={routes}>
+          <View main url="/" />
+        </F7App>
+      </KonstaApp>
     </ErrorBoundary>
   );
 }

--- a/src/hooks/useTelegramWebApp.ts
+++ b/src/hooks/useTelegramWebApp.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+
+let telegramInitialized = false;
+
+export const useTelegramWebApp = () => {
+  useEffect(() => {
+    if (telegramInitialized) {
+      console.log('⚠️ Telegram уже инициализирован');
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tg = (window as any).Telegram?.WebApp;
+    if (!tg) return;
+
+    telegramInitialized = true;
+    console.log('🚀 Единственная инициализация Telegram WebApp');
+
+    tg.ready();
+    console.log('Версия:', tg.version);
+    console.log('Платформа:', tg.platform);
+    console.log('Высота до expand:', tg.viewportHeight);
+
+    if (!tg.isExpanded) {
+      tg.expand();
+    }
+
+    setTimeout(() => {
+      console.log('Высота после expand:', tg.viewportHeight);
+      console.log('isExpanded:', tg.isExpanded);
+
+      if (tg.version >= 6.1 && !tg.isFullscreen) {
+        try {
+          tg.requestFullscreen();
+        } catch (e) {
+          console.log('Fullscreen не поддерживается');
+        }
+      }
+    }, 100);
+
+    const handleViewportChanged = () => {
+      console.log('Viewport изменен!');
+      console.log('Новая высота:', tg.viewportHeight);
+    };
+
+    tg.onEvent('viewportChanged', handleViewportChanged);
+
+    return () => {
+      tg.offEvent('viewportChanged', handleViewportChanged);
+      telegramInitialized = false;
+    };
+  }, []);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,43 +3,20 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
-declare global {
-  interface Window {
-    appStarted?: boolean;
-    telegramInitialized?: boolean;
-    htmlReady?: unknown;
-    Telegram?: {
-      WebApp?: unknown;
-    };
-  }
-}
-
-// Prevent duplicate app initialization
-if (window.appStarted) {
-  console.error('🚨 App уже запущен! Предотвращаем дублирование');
-  throw new Error('Duplicate app initialization prevented');
-}
-window.appStarted = true;
-
-// Ensure telegramInitialized flag exists for diagnostics
-if (typeof window.telegramInitialized === 'undefined') {
-  window.telegramInitialized = false;
-}
-
-// Additional logs for diagnostics
-const logExecutionContext = () => {
-  console.log('🔍 Execution Context:', {
-    location: 'React Bundle',
-    telegramInitialized: window.telegramInitialized,
-    htmlReady: window.htmlReady,
-    telegramAPI: Boolean(window.Telegram?.WebApp),
-    timestamp: new Date().toISOString(),
-  });
-};
-
-// Log execution context immediately
-logExecutionContext();
+console.log('🏁 MAIN.TSX EXECUTION START');
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <App />
 );
+
+setInterval(() => {
+  const apps = document.querySelectorAll('#root > *');
+  const mainPages = document.querySelectorAll('.main-page');
+
+  if (apps.length > 1 || mainPages.length > 1) {
+    console.error('🚨 НАЙДЕНЫ ДУБЛИКАТЫ В DOM!', {
+      apps: apps.length,
+      mainPages: mainPages.length,
+    });
+  }
+}, 2000);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,27 +5,32 @@ import MagicCat from '../components/MagicCat';
 import SplashScreen from '../components/SplashScreen';
 import TelegramUserInfo from '../components/TelegramUserInfo';
 
+let mainPageMounted = false;
+
 export default function MainPage() {
+  if (mainPageMounted) {
+    console.error('🚨 MainPage уже смонтирован!');
+    return null;
+  }
+
   const [loading, setLoading] = useState(true);
   const [modal, setModal] = useState<string | null>(null);
 
-  // ==== DEBUG RENDER LOGS ====
   const renderCount = useRef(0);
-  const [isMounted, setIsMounted] = useState(false);
-
   renderCount.current++;
 
-  console.log('🔄 MainPage RENDER:', {
-    renderCount: renderCount.current,
-    timestamp: new Date().toISOString(),
-    isMounted,
-  });
+  console.log('🔄 MainPage RENDER:', renderCount.current);
 
-  // Log component mount/unmount
   useEffect(() => {
-    console.log('📱 MainPage MOUNTED');
-    setIsMounted(true);
-    return () => console.log('💀 MainPage UNMOUNTED');
+    if (mainPageMounted) return;
+
+    mainPageMounted = true;
+    console.log('📱 MainPage MOUNTED (единственный раз)');
+
+    return () => {
+      mainPageMounted = false;
+      console.log('💀 MainPage UNMOUNTED');
+    };
   }, []);
 
   useEffect(() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [react()],
   build: {
     rollupOptions: {
+      input: 'src/main.tsx',
       external: [],
     },
   },


### PR DESCRIPTION
## Summary
- remove legacy inline Telegram init logic from index.html
- prevent duplicate app renders and Telegram WebApp reinit
- add diagnostic logging for main startup and DOM duplication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689298a249448323864609a2c5d2aad9