### PR TITLE
Fix Vite build configuration and duplicate app guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ Framework7.use(Framework7React);
 export default function App() {
   if (window.APP_INSTANCE_EXISTS) {
     console.error('🚨 App уже запущен! Блокируем дублирование');
-    return null;
+    return <div />;
   }
   window.APP_INSTANCE_EXISTS = true;
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,13 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   build: {
+    outDir: 'dist',
     rollupOptions: {
-      input: 'src/main.tsx',
-      external: [],
+      input: {
+        main: './index.html',
+      },
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- fix duplicate app initialization guard to render placeholder instead of returning null
- correct Vite build settings to emit index.html and relative asset paths

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68929a8e6698832382da016af943e79f