### PR TITLE
feat: add basic screens and services

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,73 +1,50 @@
-import React, { useEffect, useState } from 'react';
-import MainPage from './pages/MainPage';
-import { useTelegramWebApp } from './hooks/useTelegramWebApp';
+import React, { useState } from 'react';
+import LoadingScreen from './components/LoadingScreen';
+import MainMenu from './components/MainMenu';
+import NatalForm from './components/NatalForm';
+import NatalResultScreen from './components/NatalResultScreen';
+import HoroscopeScreen from './components/HoroscopeScreen';
+import GamesScreen from './components/GamesScreen';
+import ProfileScreen from './components/ProfileScreen';
 
 export default function App() {
-  const [isReady, setIsReady] = useState(false);
+  const [screen, setScreen] = useState<'loading' | 'menu' | 'natal' | 'result' | 'horoscope' | 'games' | 'profile'>('loading');
+  const [natalData, setNatalData] = useState<unknown>(null);
 
-  console.log('🎯 APP COMPONENT RENDER');
-
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const w = window as any;
-    if (w.APP_COMPONENT_MOUNTED) {
-      console.log('⚠️ App компонент уже смонтирован');
-      return;
-    }
-
-    w.APP_COMPONENT_MOUNTED = true;
-    setIsReady(true);
-
-    return () => {
-      w.APP_COMPONENT_MOUNTED = false;
-    };
-  }, []);
-
-  useTelegramWebApp();
-
-  // Мониторинг состояния каждые 3 секунды
-  useEffect(() => {
-    const interval = setInterval(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const w = window as any;
-      console.log('📊 App State:', {
-        appMounted: w.APP_COMPONENT_MOUNTED,
-        mainPageMounted: w.mainPageMountedGlobally,
-        timestamp: new Date().toISOString(),
-      });
-    }, 3000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  // Проверяем DOM на дубликаты
-  useEffect(() => {
-    const checkDuplicates = () => {
-      const mainPages = document.querySelectorAll('.main-page');
-      const roots = document.querySelectorAll('#root > *');
-
-      if (mainPages.length > 1) {
-        console.error('🚨 НАЙДЕНО ДУБЛИКАТОВ MainPage:', mainPages.length);
-        for (let i = 1; i < mainPages.length; i++) {
-          mainPages[i].remove();
-          console.log('🗑 Удален дублированный MainPage');
-        }
-      }
-
-      console.log('✅ DOM проверка:', {
-        mainPages: mainPages.length,
-        rootChildren: roots.length,
-      });
-    };
-
-    const timer = setTimeout(checkDuplicates, 1000);
-    return () => clearTimeout(timer);
-  }, []);
-
-  if (!isReady) {
-    return <div className="loading">Инициализация...</div>;
+  if (screen === 'loading') {
+    return <LoadingScreen onReady={() => setScreen('menu')} />;
   }
 
-  return <MainPage />;
-}
+  if (screen === 'menu') {
+    return <MainMenu navigate={setScreen} />;
+  }
 
+  if (screen === 'natal') {
+    return (
+      <NatalForm
+        onResult={(data) => {
+          setNatalData(data);
+          setScreen('result');
+        }}
+      />
+    );
+  }
+
+  if (screen === 'result') {
+    return <NatalResultScreen data={natalData} onBack={() => setScreen('menu')} />;
+  }
+
+  if (screen === 'horoscope') {
+    return <HoroscopeScreen onBack={() => setScreen('menu')} />;
+  }
+
+  if (screen === 'games') {
+    return <GamesScreen onBack={() => setScreen('menu')} />;
+  }
+
+  if (screen === 'profile') {
+    return <ProfileScreen onBack={() => setScreen('menu')} />;
+  }
+
+  return null;
+}

--- a/src/components/GamesScreen.tsx
+++ b/src/components/GamesScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function GamesScreen({ onBack }: Props) {
+  return (
+    <div className="p-4 text-white">
+      <button onClick={onBack} className="mb-4 underline">
+        Назад
+      </button>
+      <p>Игры (stub)</p>
+    </div>
+  );
+}

--- a/src/components/HoroscopeScreen.tsx
+++ b/src/components/HoroscopeScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function HoroscopeScreen({ onBack }: Props) {
+  return (
+    <div className="p-4 text-white">
+      <button onClick={onBack} className="mb-4 underline">
+        Назад
+      </button>
+      <p>Гороскоп (stub)</p>
+    </div>
+  );
+}

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+
+interface LoadingScreenProps {
+  onReady: () => void;
+}
+
+export default function LoadingScreen({ onReady }: LoadingScreenProps) {
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tg = (window as any).Telegram?.WebApp;
+    tg?.ready();
+    const timer = setTimeout(onReady, 1500);
+    return () => clearTimeout(timer);
+  }, [onReady]);
+
+  return (
+    <div
+      className="w-full h-screen bg-cover bg-center flex flex-col items-center justify-center text-white"
+      style={{ backgroundImage: "url('/assets/bg-loading.png')" }}
+    >
+      <img src="/assets/spinner.png" alt="loading" className="w-16 h-16 animate-spin" />
+      <p className="mt-4">Загрузка…</p>
+    </div>
+  );
+}

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Monetization } from '../lib/Monetization';
+
+interface MainMenuProps {
+  navigate: (screen: string) => void;
+}
+
+export default function MainMenu({ navigate }: MainMenuProps) {
+  return (
+    <div
+      className="w-full h-screen bg-cover bg-center flex flex-col items-center pt-10"
+      style={{ backgroundImage: "url('/assets/bg-main.png')" }}
+    >
+      <img src="/assets/cat-pose-1.png" alt="cat" className="w-40 h-40 mb-8" />
+      <div className="grid grid-cols-2 gap-4 w-full max-w-md px-4">
+        <button
+          onClick={() => navigate('natal')}
+          className="flex flex-col items-center text-white"
+        >
+          <img src="/assets/button-natal.png" alt="Натальная карта" />
+          <span>Натальная карта</span>
+        </button>
+        <button
+          onClick={() => navigate('horoscope')}
+          className="flex flex-col items-center text-white"
+        >
+          <img src="/assets/button-horoscope.png" alt="Гороскоп" />
+          <span>Гороскоп</span>
+        </button>
+        <button
+          onClick={() => navigate('games')}
+          className="flex flex-col items-center text-white"
+        >
+          <img src="/assets/button-games.png" alt="Игры" />
+          <span>Игры</span>
+        </button>
+        <button
+          onClick={() => navigate('profile')}
+          className="flex flex-col items-center text-white"
+        >
+          <img src="/assets/button-profile.png" alt="Профиль" />
+          <span>Профиль</span>
+        </button>
+        <button
+          onClick={() => Monetization.openPremium()}
+          className="flex flex-col items-center text-white col-span-2"
+        >
+          <img src="/assets/button-premium.png" alt="Премиум" />
+          <span>Премиум</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NatalForm.tsx
+++ b/src/components/NatalForm.tsx
@@ -1,38 +1,53 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { ApiService } from '../lib/ApiService';
 
 interface NatalFormProps {
-  t: {
-    name: string;
-    birthDate: string;
-    birthPlace: string;
-    submit: string;
-  };
-  onSubmit: () => void;
+  onResult: (data: unknown) => void;
 }
 
-export default function NatalForm({ t, onSubmit }: NatalFormProps) {
-  const handleSubmit = (e: React.FormEvent) => {
+export default function NatalForm({ onResult }: NatalFormProps) {
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
+  const [city, setCity] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit();
+    const payload = { name, date, time, city };
+    const res = await ApiService.postNatal(payload);
+    console.log(res);
+    onResult(res);
   };
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4 max-w-sm mx-auto">
       <input
         type="text"
-        placeholder={t.name}
+        placeholder="Имя"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
         className="rounded p-2 text-black"
         required
       />
       <input
         type="date"
-        placeholder={t.birthDate}
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="rounded p-2 text-black"
+        required
+      />
+      <input
+        type="time"
+        value={time}
+        onChange={(e) => setTime(e.target.value)}
         className="rounded p-2 text-black"
         required
       />
       <input
         type="text"
-        placeholder={t.birthPlace}
+        placeholder="Город рождения"
+        value={city}
+        onChange={(e) => setCity(e.target.value)}
         className="rounded p-2 text-black"
         required
       />
@@ -40,7 +55,7 @@ export default function NatalForm({ t, onSubmit }: NatalFormProps) {
         type="submit"
         className="bg-purple-500 hover:bg-purple-600 text-white font-semibold py-2 rounded"
       >
-        {t.submit}
+        Показать натальную карту
       </button>
     </form>
   );

--- a/src/components/NatalResultScreen.tsx
+++ b/src/components/NatalResultScreen.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+
+const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY as string;
+
+interface NatalResultScreenProps {
+  data: unknown;
+  onBack: () => void;
+}
+
+export default function NatalResultScreen({ data, onBack }: NatalResultScreenProps) {
+  const [result, setResult] = useState('');
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${OPENAI_API_KEY}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-4o-mini',
+            messages: [
+              { role: 'system', content: 'Ты — астролог…' },
+              { role: 'user', content: `Моя натальная карта: ${JSON.stringify(data)}` },
+            ],
+          }),
+        });
+        const ai = await response.json();
+        setResult(ai.choices?.[0]?.message?.content || 'Нет данных');
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    run();
+  }, [data]);
+
+  return (
+    <div className="p-4 text-white">
+      <button onClick={onBack} className="mb-4 underline">
+        Назад
+      </button>
+      <pre className="whitespace-pre-wrap">{result || 'Загрузка...'}</pre>
+    </div>
+  );
+}

--- a/src/components/ProfileScreen.tsx
+++ b/src/components/ProfileScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function ProfileScreen({ onBack }: Props) {
+  return (
+    <div className="p-4 text-white">
+      <button onClick={onBack} className="mb-4 underline">
+        Назад
+      </button>
+      <p>Профиль (stub)</p>
+    </div>
+  );
+}

--- a/src/lib/ApiService.ts
+++ b/src/lib/ApiService.ts
@@ -1,0 +1,10 @@
+export const ApiService = {
+  async postNatal(payload: unknown) {
+    const res = await fetch('https://<твой-бэк>/api/natal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return res.json();
+  },
+};

--- a/src/lib/Monetization.ts
+++ b/src/lib/Monetization.ts
@@ -1,0 +1,13 @@
+export const Monetization = {
+  openPremium() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tg = (window as any).Telegram?.WebApp;
+    if (tg?.openPaymentForm) {
+      try {
+        tg.openPaymentForm({});
+      } catch (e) {
+        console.error('Payment form error', e);
+      }
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add loading screen with spinner and Telegram WebApp init
- build main menu with navigation buttons and premium payment hook
- wire up natal form, API service, and AI-powered result screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a56fa8e0832385ab353f07b850c8