### PR TITLE
Fix sync script error in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,10 +2,15 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Providers } from './providers';
 import { BottomNav } from '@/components/BottomNav';
+import Script from 'next/script';
+import type { Viewport } from 'next';
 
 export const metadata: Metadata = {
   title: 'Deepsoul — Your Cosmic Map',
-  description: 'Legendary Telegram Web App for natal charts and cosmic insights',
+  description: 'Legendary Telegram Web App for natal charts and cosmic insights'
+};
+
+export const viewport: Viewport = {
   themeColor: '#FFF4E6'
 };
 
@@ -13,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ru" suppressHydrationWarning>
       <head>
-        <script src="https://telegram.org/js/telegram-web-app.js" />
+        <Script src="https://telegram.org/js/telegram-web-app.js" strategy="beforeInteractive" />
       </head>
       <body className="min-h-dvh flex flex-col">
         <main className="flex-1 pb-20">


### PR DESCRIPTION
Replace synchronous script with `next/script` and move `themeColor` to `viewport` to resolve build errors and comply with Next.js 14.

---
<a href="https://cursor.com/background-agent?bcId=bc-b560c9ce-fbd9-4921-a652-d30042c7d9e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b560c9ce-fbd9-4921-a652-d30042c7d9e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

