### PR TITLE
Add consistent top padding for safe area

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,6 +37,11 @@ body {
   padding-top: env(safe-area-inset-top);
 }
 
+/* Safe-area aware top padding with additional base spacing */
+.safe-top-16 {
+  padding-top: calc(env(safe-area-inset-top) + 16px);
+}
+
 /* Typography */
 .typ-h1 { font-size: 28px; line-height: 34px; font-weight: 700; }
 .typ-h2 { font-size: 22px; line-height: 28px; font-weight: 600; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-dvh h-dvh flex flex-col">
         <main className="flex-1 h-full pb-20">
           <Providers>
-            <div className="px-4 pt-6 pb-4 max-w-lg mx-auto">{children}</div>
+            <div className="px-4 safe-top-16 pb-4 max-w-lg mx-auto">{children}</div>
           </Providers>
         </main>
         <BottomNav />


### PR DESCRIPTION
Adds a global safe-area aware top padding to the main content container to ensure consistent spacing and prevent content overlap on all screens.

This change addresses the issue where content could be obscured by the top edge or UI elements (like a "Close" button), particularly on devices with display cutouts (notches). By using `env(safe-area-inset-top)` combined with a fixed `16px` padding, the content is always appropriately offset from the top, adapting to different device layouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5f7451f-a638-4588-8736-463687a5fa95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5f7451f-a638-4588-8736-463687a5fa95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

