### PR TITLE
Implement global safe area top padding

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,8 @@
 :root {
   --glass-bg: 255 255 255 / 0.65;
   --glass-stroke: 17 24 39 / 0.08;
+  --top-bar-min: 56px; /* минимальная высота верхней панели/кнопки */
+  --top-gap: 16px;     /* дополнительный воздух */
 }
 
 html, body, #__next {
@@ -34,7 +36,12 @@ body {
   padding-bottom: env(safe-area-inset-bottom);
 }
 .safe-top {
-  padding-top: env(safe-area-inset-top);
+  padding-top: calc(max(env(safe-area-inset-top), var(--top-bar-min)) + var(--top-gap));
+}
+
+/* Fallback, если env() недоступен */
+@supports not (padding-top: env(safe-area-inset-top)) {
+  .safe-top { padding-top: calc(56px + 16px); }
 }
 
 /* Safe-area aware top padding with additional base spacing */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,10 +20,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <Script src="https://telegram.org/js/telegram-web-app.js" strategy="beforeInteractive" />
       </head>
-      <body className="min-h-dvh h-dvh flex flex-col">
+      <body className="min-h-dvh h-dvh flex flex-col safe-top">
         <main className="flex-1 h-full pb-20">
           <Providers>
-            <div className="px-4 safe-top-16 pb-4 max-w-lg mx-auto">{children}</div>
+            <div className="px-4 pb-4 max-w-lg mx-auto">{children}</div>
           </Providers>
         </main>
         <BottomNav />


### PR DESCRIPTION
Add global adaptive top offset to prevent content overlap by Telegram Mini App's top bar and close button on iOS.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3b45311-9d60-4c76-91d9-7856fa699e71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3b45311-9d60-4c76-91d9-7856fa699e71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

