### PR TITLE
feat(layout): global top offset = safe-area + headerMin + gap; preven…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,8 +5,8 @@
 :root {
   --glass-bg: 255 255 255 / 0.65;
   --glass-stroke: 17 24 39 / 0.08;
-  --top-bar-min: 56px; /* минимальная высота верхней панели/кнопки */
-  --top-gap: 16px;     /* дополнительный воздух */
+  --top-bar-min: 64px; /* минимальная высота верхней панели/кнопки */
+  --top-gap: 24px;     /* дополнительный воздух */
 }
 
 html, body, #__next {
@@ -36,12 +36,12 @@ body {
   padding-bottom: env(safe-area-inset-bottom);
 }
 .safe-top {
-  padding-top: calc(max(env(safe-area-inset-top), var(--top-bar-min)) + var(--top-gap));
+  padding-top: calc(env(safe-area-inset-top) + var(--top-bar-min) + var(--top-gap));
 }
 
 /* Fallback, если env() недоступен */
 @supports not (padding-top: env(safe-area-inset-top)) {
-  .safe-top { padding-top: calc(56px + 16px); }
+  .safe-top { padding-top: max(calc(var(--top-bar-min) + var(--top-gap)), 96px); }
 }
 
 /* Safe-area aware top padding with additional base spacing */

--- a/app/telegram-context.tsx
+++ b/app/telegram-context.tsx
@@ -50,8 +50,21 @@ export function TelegramProvider({ children }: { children: React.ReactNode }) {
       tg.setHeaderColor(header);
       tg.setBackgroundColor(bg);
 
-      // Push theme to CSS variables for glass contrast
+      // Platform-aware top spacing tokens
+      const platform: string = tg.platform || '';
       const root = document.documentElement;
+      if (platform === 'ios') {
+        root.style.setProperty('--top-bar-min', '72px');
+        root.style.setProperty('--top-gap', '24px');
+      } else if (platform === 'android') {
+        root.style.setProperty('--top-bar-min', '64px');
+        root.style.setProperty('--top-gap', '20px');
+      } else {
+        root.style.setProperty('--top-bar-min', '64px');
+        root.style.setProperty('--top-gap', '20px');
+      }
+
+      // Push theme to CSS variables for glass contrast
       root.style.setProperty('--glass-bg', '255 255 255 / 0.65');
       root.style.setProperty('--glass-stroke', '17 24 39 / 0.08');
 


### PR DESCRIPTION
…t overlap with Telegram ‘Close’ button across all screens\n\n- Add platform-aware CSS vars for --top-bar-min and --top-gap (iOS/Android/Desktop)\n- Increase defaults (64–72px header, 20–24px gap), sum with env(safe-area-inset-top)\n- Improve fallback when env() unavailable (>=96px)\n- Centralize at root layout via .safe-top on <body>\n- No changes to inner components spacing