### PR TITLE
Запустить приложение в полноэкранном режиме и закрепить

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Astrot",
+  "short_name": "Astrot",
+  "start_url": "/",
+  "scope": "/",
+  "display": "fullscreen",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "lang": "ru",
+  "dir": "ltr",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ru" suppressHydrationWarning>
       <head>
+        <meta name="theme-color" content="#000000" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <link rel="manifest" href="/manifest.webmanifest" />
         <Script src="https://telegram.org/js/telegram-web-app.js" strategy="beforeInteractive" />
       </head>
       <body className="min-h-[100svh] bg-bg text-text font-sans">

--- a/src/providers/telegram-provider.tsx
+++ b/src/providers/telegram-provider.tsx
@@ -88,7 +88,7 @@ export function TelegramProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    const webApp = initTelegram({ ready: true, expand: true });
+    const webApp = initTelegram({ ready: true, expand: true, enableClosingConfirmation: true });
     if (!webApp) return;
     setTg(webApp);
     const tp = webApp.themeParams ?? {};
@@ -110,6 +110,9 @@ export function TelegramProvider({ children }: { children: React.ReactNode }) {
     const offViewport = onTelegramEvent('viewportChanged', () => {
       const vh = webApp.viewportHeight ?? window.innerHeight;
       document.documentElement.style.setProperty('--tg-viewport-height', `${vh}px`);
+      try {
+        webApp.expand?.();
+      } catch {}
     });
 
     return () => {


### PR DESCRIPTION
Configure the application to open in full-screen mode and prevent accidental closure for Telegram Mini App and PWA.

---
<a href="https://cursor.com/background-agent?bcId=bc-1575a158-ca8e-4a90-8f41-30e482d43301">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1575a158-ca8e-4a90-8f41-30e482d43301">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

