### PR TITLE
Request fullscreen on Telegram WebApp startup

### DIFF
--- a/__tests__/lib/telegram.test.ts
+++ b/__tests__/lib/telegram.test.ts
@@ -2,15 +2,21 @@ import { getTelegramWebApp, initTelegram } from '@/lib/telegram';
 
 describe('telegram', () => {
   test('getTelegramWebApp returns null without window.Telegram', () => {
-    // Ensure no window
-    // @ts-ignore
-    global.window = undefined;
     expect(getTelegramWebApp()).toBeNull();
   });
 
   test('initTelegram does not throw without SDK', () => {
-    // @ts-ignore
-    global.window = {};
     expect(() => initTelegram()).not.toThrow();
+  });
+
+  test('initTelegram requests fullscreen when option is set', () => {
+    const requestFullscreen = jest.fn();
+    const ready = jest.fn();
+    // @ts-ignore
+    window.Telegram = { WebApp: { requestFullscreen, ready } };
+    initTelegram({ requestFullscreen: true });
+    expect(requestFullscreen).toHaveBeenCalled();
+    // @ts-ignore
+    delete window.Telegram;
   });
 });

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -27,6 +27,7 @@ export type TelegramThemeParams = Record<string, string>;
 export type TelegramWebApp = {
   ready: () => void;
   expand: () => void;
+  requestFullscreen?: () => void;
   enableClosingConfirmation?: () => void;
   onEvent?: (event: 'themeChanged' | 'viewportChanged', handler: (payload?: unknown) => void) => void;
   offEvent?: (event: 'themeChanged' | 'viewportChanged', handler: (payload?: unknown) => void) => void;
@@ -49,12 +50,18 @@ export function getTelegramWebApp(): TelegramWebApp | null {
   return tg ?? null;
 }
 
-export function initTelegram(options?: { ready?: boolean; expand?: boolean; enableClosingConfirmation?: boolean }) {
+export function initTelegram(options?: {
+  ready?: boolean
+  expand?: boolean
+  requestFullscreen?: boolean
+  enableClosingConfirmation?: boolean
+}) {
   const tg = getTelegramWebApp();
   if (!tg) return null;
   try {
     if (options?.ready !== false) tg.ready();
     if (options?.expand) tg.expand();
+    if (options?.requestFullscreen) tg.requestFullscreen?.();
     if (options?.enableClosingConfirmation) tg.enableClosingConfirmation?.();
   } catch {
     // ignore

--- a/src/providers/telegram-viewport.tsx
+++ b/src/providers/telegram-viewport.tsx
@@ -32,16 +32,24 @@ export function TelegramViewportProvider({ children }: { children: React.ReactNo
 		const tg = w?.Telegram?.WebApp
 		if (!tg) return
 
-		// Готовность и ранний expand
-		try { tg.ready?.() } catch {}
-		try { tg.expand?.() } catch {}
-		// fallback через официальный SDK (инициализация и expand, если возможно)
-		let sdkCleanup: (() => void) | undefined
-		try {
-			const [vpPromise, cleanup] = initViewport()
-			sdkCleanup = cleanup
-			vpPromise.then((vp) => { try { if (!vp.isExpanded) vp.expand() } catch {} }).catch(() => {})
-		} catch {}
+                // Готовность и ранний expand
+                try { tg.ready?.() } catch {}
+                try { tg.expand?.() } catch {}
+                try { tg.requestFullscreen?.() } catch {}
+                // fallback через официальный SDK (инициализация и expand, если возможно)
+                let sdkCleanup: (() => void) | undefined
+                try {
+                        const [vpPromise, cleanup] = initViewport()
+                        sdkCleanup = cleanup
+                        vpPromise
+                                .then((vp) => {
+                                        try {
+                                                if (!vp.isExpanded) vp.expand()
+                                                ;(vp as { requestFullscreen?: () => void }).requestFullscreen?.()
+                                        } catch {}
+                                })
+                                .catch(() => {})
+                } catch {}
 
 		const updateHeights = () => {
 			const h = (tg as { viewportHeight?: number }).viewportHeight ?? tg.viewportHeight ?? 0


### PR DESCRIPTION
## Summary
- request Telegram WebApp fullscreen as part of init and viewport setup
- add tests for fullscreen request

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d666296cc8323b8b8ac25a21fe16e