### PR TITLE
feat: request closing confirmation to keep fullscreen

### DIFF
--- a/__tests__/lib/telegram.test.ts
+++ b/__tests__/lib/telegram.test.ts
@@ -19,4 +19,15 @@ describe('telegram', () => {
     // @ts-ignore
     delete window.Telegram;
   });
+
+  test('initTelegram enables closing confirmation when option is set', () => {
+    const enableClosingConfirmation = jest.fn();
+    const ready = jest.fn();
+    // @ts-ignore
+    window.Telegram = { WebApp: { enableClosingConfirmation, ready } };
+    initTelegram({ enableClosingConfirmation: true });
+    expect(enableClosingConfirmation).toHaveBeenCalled();
+    // @ts-ignore
+    delete window.Telegram;
+  });
 });

--- a/src/providers/telegram-viewport.tsx
+++ b/src/providers/telegram-viewport.tsx
@@ -36,6 +36,7 @@ export function TelegramViewportProvider({ children }: { children: React.ReactNo
                 try { tg.ready?.() } catch {}
                 try { tg.expand?.() } catch {}
                 try { tg.requestFullscreen?.() } catch {}
+                try { tg.enableClosingConfirmation?.() } catch {}
                 // fallback через официальный SDK (инициализация и expand, если возможно)
                 let sdkCleanup: (() => void) | undefined
                 try {
@@ -46,6 +47,7 @@ export function TelegramViewportProvider({ children }: { children: React.ReactNo
                                         try {
                                                 if (!vp.isExpanded) vp.expand()
                                                 ;(vp as { requestFullscreen?: () => void }).requestFullscreen?.()
+                                                ;(vp as { enableClosingConfirmation?: () => void }).enableClosingConfirmation?.()
                                         } catch {}
                                 })
                                 .catch(() => {})


### PR DESCRIPTION
## Summary
- call enableClosingConfirmation when initializing Telegram WebApp viewport so the app stays fullscreen
- cover enableClosingConfirmation option with tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6a25adcc83238d0cadf7bde434e1