### PR TITLE
Исправить рантайм PHP в конфиге Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,9 @@
       "memory": 1024,
       "maxDuration": 10,
       "includeFiles": "ephe/**"
+    },
+    "api/*.php": {
+      "runtime": "vercel-php@0.6.0"
     }
   }
 }


### PR DESCRIPTION
Add explicit `vercel-php@0.6.0` runtime to `vercel.json`.

This resolves the Vercel deployment error "Function Runtimes must have a valid version" by overriding any implicit or legacy `now-php` runtime settings, even if no PHP files are present in the project.

---
<a href="https://cursor.com/background-agent?bcId=bc-01e1f560-f3f4-4b2a-942c-71f33347ea69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01e1f560-f3f4-4b2a-942c-71f33347ea69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

