### PR TITLE
fix vercel build runtime config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,6 @@
       "memory": 1024,
       "maxDuration": 10,
       "includeFiles": "ephe/**"
-    },
-    "api/*.php": {
-      "runtime": "vercel-php@0.6.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove legacy PHP function runtime configuration

## Testing
- `pnpm lint`
- `pnpm test`
- `npx vercel build --version` *(fails: Failed to get package info: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689e101090e08323b7e00a0db8d4835a