### PR TITLE
Fix vercel function runtime configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@9.6.0",
   "engines": {
-    "node": "^20"
+    "node": "20.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-	"version": 2
+	"version": 2,
+	"functions": {
+		"src/app/api/**/route.ts": {
+			"runtime": "nodejs20.x",
+			"maxDuration": 10
+		}
+	}
 }


### PR DESCRIPTION
Explicitly configure Node.js runtime in `vercel.json` and `package.json` to fix "Function Runtimes must have a valid version" error on Vercel.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d96d0f5-cb12-4749-acd3-b49b92d46cbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d96d0f5-cb12-4749-acd3-b49b92d46cbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

