### PR TITLE
Fix vercel build runtime version error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-	"version": 2,
-	"functions": {
-		"src/app/api/**/route.ts": {
-			"runtime": "nodejs20.x",
-			"maxDuration": 10
-		}
-	}
-}


### PR DESCRIPTION
Remove `vercel.json` to resolve Vercel build error due to conflicting function runtime configuration.

The `vercel.json` file contained a `functions` section that is not needed for Next.js App Router projects and caused the build to fail with "Function Runtimes must have a valid version".

---
<a href="https://cursor.com/background-agent?bcId=bc-ba4db67d-12b9-4500-bb09-e1418583af20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba4db67d-12b9-4500-bb09-e1418583af20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

