### PR TITLE
chore(vercel): correct API function patterns and exclude heavy ephe files from bundle

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,20 @@
 {
   "functions": {
-    "api/**": {
-      "excludeFiles": "{ephe/sat/**,ephe/seasnam.txt}"
+    "app/api/**/route.js": {
+      "excludeFiles": "{ephe/sat/**,ephe/seasnam.txt}",
+      "includeFiles": "ephe/{sepl_*,seplm*,semo_*,semom*}"
+    },
+    "app/api/**/route.ts": {
+      "excludeFiles": "{ephe/sat/**,ephe/seasnam.txt}",
+      "includeFiles": "ephe/{sepl_*,seplm*,semo_*,semom*}"
+    },
+    "pages/api/**/*.js": {
+      "excludeFiles": "{ephe/sat/**,ephe/seasnam.txt}",
+      "includeFiles": "ephe/{sepl_*,seplm*,semo_*,semom*}"
+    },
+    "pages/api/**/*.ts": {
+      "excludeFiles": "{ephe/sat/**,ephe/seasnam.txt}",
+      "includeFiles": "ephe/{sepl_*,seplm*,semo_*,semom*}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- specify Next.js API route patterns for app and pages routers
- exclude heavy ephemeris data from serverless bundles while including required files

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd6ee825c8323b402718c739ee524