### PR TITLE
Fix vercel function runtime version error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "api/**.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "api/**.{js,ts}": { "runtime": "nodejs@20" },
+    "app/**/route.{js,ts}": { "runtime": "nodejs@20" }
   }
 }


### PR DESCRIPTION
Fix Vercel runtime version format to resolve deployment error.

The previous runtime format `nodejs20.x` was incorrect; Vercel requires the format `nodejs@20` for function runtimes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca96807d-f2c9-4dda-9e18-02e6cc56cbbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca96807d-f2c9-4dda-9e18-02e6cc56cbbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

