### PR TITLE
Fix vercel deploy runtime error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,1 @@
-{
-  "functions": {
-    "api/**.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/**/route.{js,ts}": { "runtime": "nodejs20.x" }
-  }
-}
+{}


### PR DESCRIPTION
Remove redundant `functions` configuration from `vercel.json` to fix Vercel deployment error.

The global `functions` configuration in `vercel.json` conflicted with Next.js 14's App Router and individual API route runtime settings, leading to the "Function Runtimes must have a valid version" error during deployment. Removing it allows Vercel to correctly infer runtimes.

---
<a href="https://cursor.com/background-agent?bcId=bc-148c8a39-0947-42c3-9608-3c4e09a90b35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-148c8a39-0947-42c3-9608-3c4e09a90b35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

