### PR TITLE
Use next/image and font to fix lint warnings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,7 +12,10 @@ const nextConfig = {
   transpilePackages: [
     '@telegram-apps/sdk',
     '@telegram-apps/sdk-react'
-  ]
+  ],
+  eslint: {
+    ignoreDuringBuilds: false,
+  }
 };
 
 export default nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,15 @@
-'use client';
 import Script from 'next/script';
 import '@/app/globals.css';
 import { TelegramProvider } from '@/providers/telegram-provider';
 import { TelegramViewportProvider } from '@/providers/telegram-viewport';
 import NavBar from '@/components/NavBar';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({
+  subsets: ['latin', 'cyrillic'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+});
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -14,11 +20,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <Script src="https://telegram.org/js/telegram-web-app.js" strategy="beforeInteractive" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </head>
-      <body>
+      <body className={inter.className}>
         <TelegramProvider>
           <TelegramViewportProvider>
             <div className="app-container">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useTelegramUser, useTelegram } from '@/hooks/useTelegram';
 import { StarIcon, SparklesIcon } from '@heroicons/react/24/outline';
 
 export default function HomePage() {
-  const { firstName, lastName, photoUrl } = useTelegramUser();
+  const { firstName, photoUrl } = useTelegramUser();
   const { hapticFeedback } = useTelegram();
   const [greeting, setGreeting] = useState('');
 
@@ -30,9 +31,12 @@ export default function HomePage() {
         <div className="mb-6">
           {photoUrl ? (
             <div className="relative">
-              <img 
-                src={photoUrl} 
+              <Image
+                src={photoUrl}
                 alt={firstName}
+                width={96}
+                height={96}
+                unoptimized
                 className="w-24 h-24 rounded-full border-4 border-white shadow-lg mx-auto"
               />
               <div className="absolute -bottom-2 -right-2 w-8 h-8 bg-gradient-to-br from-purple-500 to-pink-500 rounded-full flex items-center justify-center border-2 border-white">
@@ -78,7 +82,7 @@ export default function HomePage() {
           <div className="flex items-center justify-center gap-2 text-purple-700">
             <StarIcon className="w-5 h-5" />
             <span className="text-sm font-medium">
-              Исследуйте все возможности в разделе "Функции"
+              Исследуйте все возможности в разделе &quot;Функции&quot;
             </span>
           </div>
         </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Image from 'next/image';
 import { useTelegramUser, useTelegram } from '@/hooks/useTelegram';
 import { useRouter } from 'next/navigation';
 import { BellIcon, ShieldCheckIcon, QuestionMarkCircleIcon, StarIcon, UserIcon } from '@heroicons/react/24/outline';
@@ -50,9 +51,12 @@ export default function ProfilePage() {
         <div className="bg-gradient-to-br from-pastel-purple via-pastel-pink to-pastel-peach p-6 rounded-2xl shadow-card">
           <div className="flex items-center gap-4 mb-4">
             {photoUrl ? (
-              <img 
-                src={photoUrl} 
+              <Image
+                src={photoUrl}
                 alt={fullName}
+                width={80}
+                height={80}
+                unoptimized
                 className="w-20 h-20 rounded-full border-4 border-white shadow-lg"
               />
             ) : (


### PR DESCRIPTION
## Summary
- Replace `img` tags with Next.js `Image` component
- Escape JSX quotes and remove unused variables
- Load Inter font via `next/font` and enforce ESLint during build

## Testing
- `pnpm test`
- `OPENAI_API_KEY=dummy pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a187c5b4f8832398d0fafb404a5675