### PR TITLE
Fix astro calc import with gateway module

### DIFF
--- a/src/lib/astro/calc.ts
+++ b/src/lib/astro/calc.ts
@@ -1,0 +1,5 @@
+// Gateway module for @/lib/astro/calc imports
+// Re-exports ephemeris adapter and existing calc functionality
+
+export * from '../../../lib/ephemeris/adapter';
+export * from '../../../lib/astro/calc';


### PR DESCRIPTION
Create `src/lib/astro/calc.ts` gateway module to resolve `@/lib/astro/calc` import and re-export necessary modules.

---
<a href="https://cursor.com/background-agent?bcId=bc-d98a88a1-9997-4e8d-b9dc-2ee7dc601432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d98a88a1-9997-4e8d-b9dc-2ee7dc601432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

