### PR TITLE
feat: add art background to natal wheel

### DIFF
--- a/public/art/natal-wheel-bg.svg
+++ b/public/art/natal-wheel-bg.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="768" height="768">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#C1B2FF" stop-opacity="0.8"/>
+      <stop offset="60%" stop-color="#F5A8E9" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F5A8E9" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#bg)"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -283,6 +283,21 @@ p {
   animation: scaleIn 0.2s ease-out;
 }
 
+@keyframes spin360 {
+  from { transform: rotate(0); }
+  to { transform: rotate(360deg); }
+}
+
+.animate-slow-spin {
+  animation: spin360 120s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-slow-spin {
+    animation: none;
+  }
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -211,13 +211,14 @@ export default function HomePage() {
         {/* Натальный круг или CTA */}
         {chart ? (
           <div className="mt-4 flex justify-center">
-            <NatalWheel 
-              data={chart} 
-              size={320} 
+            <NatalWheel
+              data={chart}
+              size={320}
+              art={{ src: '/art/natal-wheel-bg.svg', rotate: true, opacity: 0.9 }}
               onSelect={(e) => {
                 console.log('select', e);
                 hapticFeedback('impact', 'light');
-              }} 
+              }}
             />
           </div>
         ) : birth ? (


### PR DESCRIPTION
## Summary
- add slow spin animation utility and reduced-motion guard
- support optional art background with glow in `NatalWheel`
- render natal wheel with rotating art on home page
- replace PNG background with text-based SVG to avoid binary files

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af306b9c8323abdae81b5c62c598