### PR TITLE
Fix build type errors and warnings

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -207,7 +207,7 @@ export default function HomePage() {
 
         {/* Всегда показываем колесо */}
         <div className="mt-6 flex justify-center">
-          {chart && chart !== 'error' ? (
+          {chart && chart !== 'error' && chart !== 'loading' && typeof chart === 'object' ? (
             <NatalWheel data={chart} size={320} onSelect={(e) => openInsight(e)} />
           ) : (
             <img


### PR DESCRIPTION
Fixes a TypeScript compilation error by adding type checks for the `chart` prop passed to `NatalWheel` component.

The `chart` state could be a string ('loading' or 'error') or `null`, but the `NatalWheel` component strictly expected a `ChartData` object, leading to a type mismatch during the build process. The added checks ensure `NatalWheel` only receives valid `ChartData`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2725a146-5940-49cd-8af4-765be25aecd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2725a146-5940-49cd-8af4-765be25aecd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

