### PR TITLE
fix: provide supabase url for prod builds

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,12 @@ const nextConfig = {
     '@telegram-apps/sdk',
     '@telegram-apps/sdk-react'
   ],
+  env: {
+    // Ensure Supabase URL is available during production builds. Fallback to
+    // SUPABASE_URL when only server-side vars are configured.
+    NEXT_PUBLIC_SUPABASE_URL:
+      process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  },
   eslint: {
     ignoreDuringBuilds: false,
   }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -15,7 +15,18 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Supabase Client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+// Allow using SUPABASE_URL as a fallback so production builds work even when
+// only server-side env vars are configured. Throw a clear error if neither is
+// provided.
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+
+if (!supabaseUrl) {
+  throw new Error(
+    'Supabase URL is required. Set NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL.'
+  )
+}
+
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
 


### PR DESCRIPTION
## Summary
- allow SUPABASE_URL fallback to satisfy production builds
- expose Supabase URL through Next.js config

## Testing
- `SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service pnpm test`
- `SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a909051cd48323be1590d51368cd21