### PR TITLE
Fix top bar overlap with safe area

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -15,7 +15,8 @@ interface TelegramUser {
 
 /**
  * TopBar компонент для Telegram WebApp
- * Высота: 56px + отступ сверху calc(env(safe-area-inset-top) + 8px)
+ * Высота: 56px + отступ сверху calc(env(safe-area-inset-top) + 20px)
+ * Увеличенный отступ для кнопки закрытия Telegram
  */
 export default function TopBar() {
   const [user, setUser] = useState<TelegramUser | null>(null)
@@ -50,7 +51,7 @@ export default function TopBar() {
     <header 
       className="fixed top-0 left-0 right-0 z-50"
       style={{
-        paddingTop: 'calc(env(safe-area-inset-top) + 8px)',
+        paddingTop: 'calc(env(safe-area-inset-top, 0px) + 20px)',
       }}
     >
       <div className="mx-auto max-w-screen-md px-4">


### PR DESCRIPTION
Increase `TopBar` `padding-top` and add `safe-area-inset-top` fallback to prevent overlap with Telegram Mini App's close button.

The previous `paddingTop: 'calc(env(safe-area-inset-top) + 8px)'` was insufficient in Telegram Mini Apps, leading to the `TopBar` obscuring the system close button. This change increases the additional padding to `20px` and adds a `0px` fallback for `env(safe-area-inset-top)` to ensure universal compatibility and sufficient clearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c7bd8d2-0d8d-4177-bd5f-3c51da59b04e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c7bd8d2-0d8d-4177-bd5f-3c51da59b04e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

